### PR TITLE
Refactor API into service-oriented async architecture

### DIFF
--- a/app/clients/java.py
+++ b/app/clients/java.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+from app.services.exceptions import DownstreamServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class JavaServiceClient:
+    """Async HTTP client responsible for communicating with the Java backend."""
+
+    def __init__(
+        self,
+        base_url: str | None,
+        *,
+        timeout: float = 10.0,
+        use_mock_data: bool = True,
+    ) -> None:
+        self._base_url = base_url.rstrip("/") if base_url else None
+        self._timeout = timeout
+        self.use_mock_data = use_mock_data or not self._base_url
+        self._client: Optional[httpx.AsyncClient] = None
+        if not self.use_mock_data and self._base_url:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout)
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        if self.use_mock_data or not self._base_url:
+            raise RuntimeError("HTTP client requested while running in mock mode")
+        if self._client is None:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout)
+        return self._client
+
+    async def post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if self.use_mock_data:
+            raise RuntimeError("Real HTTP call requested while mock mode is enabled")
+        client = await self._ensure_client()
+        try:
+            response = await client.post(path, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            logger.exception("Java service returned error %s", exc.response.status_code)
+            raise DownstreamServiceError(
+                "Java service returned an error response",
+                status_code=exc.response.status_code,
+                cause=exc,
+            ) from exc
+        except httpx.RequestError as exc:
+            logger.exception("Unable to reach Java service: %s", exc)
+            raise DownstreamServiceError(
+                "Unable to reach Java service", status_code=None, cause=exc
+            ) from exc
+
+    async def simulate_latency(self) -> None:
+        """Allow services to await for latency even when mocking responses."""
+
+        await asyncio.sleep(0)
+

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,44 @@
+from functools import lru_cache
+from typing import List
+
+from pydantic import AnyHttpUrl, BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    app_name: str = Field(default="QTick MCP Service", alias="APP_NAME")
+    cors_origins: List[AnyHttpUrl] = Field(
+        default_factory=lambda: [
+            "http://localhost:5500",
+            "http://127.0.0.1:5500",
+        ]
+    )
+    java_service_base_url: AnyHttpUrl | None = Field(
+        default=None, alias="JAVA_SERVICE_BASE_URL"
+    )
+    java_service_timeout: float = Field(default=10.0, alias="JAVA_SERVICE_TIMEOUT")
+    use_mock_data: bool = Field(default=True, alias="USE_MOCK_DATA")
+    google_api_key: str | None = Field(default=None, alias="GOOGLE_API_KEY")
+    agent_google_model: str = Field(default="gemini-1.5-flash", alias="AGENT_GOOGLE_MODEL")
+    agent_temperature: float = Field(default=0.0, alias="AGENT_TEMPERATURE")
+    mcp_base_url: AnyHttpUrl = Field(
+        default="http://localhost:8000", alias="MCP_BASE_URL"
+    )
+
+    class Config:
+        env_prefix = "QTICK_"
+        case_sensitive = False
+
+    @validator("cors_origins", pre=True)
+    def _split_origins(cls, value):
+        if isinstance(value, str):
+            return [origin.strip() for origin in value.split(",") if origin.strip()]
+        return value
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/app/dependencies/services.py
+++ b/app/dependencies/services.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import Depends
+
+from app.clients.java import JavaServiceClient
+from app.config import Settings, get_settings
+from app.services import (
+    AnalyticsService,
+    AppointmentService,
+    CampaignService,
+    InvoiceService,
+    LeadService,
+)
+
+
+@lru_cache(maxsize=1)
+def get_java_client_cached() -> JavaServiceClient:
+    settings = get_settings()
+    return JavaServiceClient(
+        settings.java_service_base_url,
+        timeout=settings.java_service_timeout,
+        use_mock_data=settings.use_mock_data,
+    )
+
+
+def get_java_client(settings: Settings = Depends(get_settings)) -> JavaServiceClient:
+    return get_java_client_cached()
+
+
+def get_appointment_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> AppointmentService:
+    return AppointmentService(client)
+
+
+def get_invoice_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> InvoiceService:
+    return InvoiceService(client)
+
+
+def get_lead_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> LeadService:
+    return LeadService(client)
+
+
+def get_campaign_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> CampaignService:
+    return CampaignService(client)
+
+
+def get_analytics_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> AnalyticsService:
+    return AnalyticsService(client)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,13 @@
+from .appointment import AppointmentService
+from .analytics import AnalyticsService
+from .campaign import CampaignService
+from .invoice import InvoiceService
+from .leads import LeadService
+
+__all__ = [
+    "AppointmentService",
+    "AnalyticsService",
+    "CampaignService",
+    "InvoiceService",
+    "LeadService",
+]

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+
+from app.clients.java import JavaServiceClient
+from app.schemas.analytics import AnalyticsRequest, AnalyticsResponse
+from app.services.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class AnalyticsService:
+    def __init__(self, client: JavaServiceClient) -> None:
+        self._client = client
+
+    async def generate_report(self, request: AnalyticsRequest) -> AnalyticsResponse:
+        logger.debug("Generating analytics for business %s", request.business_id)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            return AnalyticsResponse(
+                footfall=42,
+                revenue="SGD 1,540",
+                report_generated_at="2025-09-05T15:03:10+08:00",
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/analytics/report", payload)
+            return AnalyticsResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while generating analytics")
+            raise ServiceError("Failed to generate analytics report", cause=exc)

--- a/app/services/appointment.py
+++ b/app/services/appointment.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from app.clients.java import JavaServiceClient
+from app.schemas.appointment import (
+    AppointmentListRequest,
+    AppointmentListResponse,
+    AppointmentRequest,
+    AppointmentResponse,
+    AppointmentSummary,
+)
+from app.services.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class AppointmentService:
+    def __init__(self, client: JavaServiceClient) -> None:
+        self._client = client
+
+    async def book(self, request: AppointmentRequest) -> AppointmentResponse:
+        logger.debug("Booking appointment for %s", request.customer_name)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            return AppointmentResponse(
+                status="confirmed",
+                appointment_id="APT-33451",
+                queue_number="B17",
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/appointments/book", payload)
+            return AppointmentResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while booking appointment")
+            raise ServiceError("Failed to book appointment", cause=exc)
+
+    async def list(self, request: AppointmentListRequest) -> AppointmentListResponse:
+        logger.debug("Listing appointments for business %s", request.business_id)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            items: List[AppointmentSummary] = [
+                AppointmentSummary(
+                    appointment_id="APT-33451",
+                    customer_name="Alex",
+                    service_id="haircut",
+                    datetime="2025-09-06T17:00:00+08:00",
+                    status="confirmed",
+                    queue_number="B17",
+                ),
+                AppointmentSummary(
+                    appointment_id="APT-33452",
+                    customer_name="Jane",
+                    service_id="facial",
+                    datetime="2025-09-06T18:30:00+08:00",
+                    status="pending",
+                    queue_number=None,
+                ),
+            ]
+            start = (request.page - 1) * request.page_size
+            end = start + request.page_size
+            return AppointmentListResponse(
+                total=len(items),
+                page=request.page,
+                page_size=request.page_size,
+                items=items[start:end],
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/appointments/list", payload)
+            return AppointmentListResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while listing appointments")
+            raise ServiceError("Failed to list appointments", cause=exc)

--- a/app/services/campaign.py
+++ b/app/services/campaign.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+from app.clients.java import JavaServiceClient
+from app.schemas.campaign import CampaignRequest, CampaignResponse
+from app.services.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class CampaignService:
+    def __init__(self, client: JavaServiceClient) -> None:
+        self._client = client
+
+    async def send_whatsapp(self, request: CampaignRequest) -> CampaignResponse:
+        logger.debug("Sending WhatsApp campaign to %s", request.phone_number)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            return CampaignResponse(
+                status="sent",
+                delivery_time="2025-09-05T15:02:03+08:00",
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/campaigns/whatsapp", payload)
+            return CampaignResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while sending campaign")
+            raise ServiceError("Failed to send campaign", cause=exc)

--- a/app/services/exceptions.py
+++ b/app/services/exceptions.py
@@ -1,0 +1,14 @@
+class ServiceError(Exception):
+    """Base exception for service layer failures."""
+
+    def __init__(self, message: str, *, cause: Exception | None = None):
+        super().__init__(message)
+        self.cause = cause
+
+
+class DownstreamServiceError(ServiceError):
+    """Raised when an external service returns an error response."""
+
+    def __init__(self, message: str, status_code: int | None = None, *, cause: Exception | None = None):
+        super().__init__(message, cause=cause)
+        self.status_code = status_code

--- a/app/services/invoice.py
+++ b/app/services/invoice.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from app.clients.java import JavaServiceClient
+from app.schemas.billing import InvoiceRequest, InvoiceResponse
+from app.services.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class InvoiceService:
+    def __init__(self, client: JavaServiceClient) -> None:
+        self._client = client
+
+    async def create(self, request: InvoiceRequest) -> InvoiceResponse:
+        logger.debug("Creating invoice for %s", request.customer_name)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            total = 0.0
+            for item in request.items:
+                unit_price = getattr(item, "unit_price", None)
+                if unit_price is None:
+                    unit_price = getattr(item, "price", None)
+                if unit_price is None:
+                    unit_price = 0.0
+                line_total = float(item.quantity) * float(unit_price)
+                line_total *= 1.0 + float(item.tax_rate)
+                total += line_total
+            total = round(total, 2)
+            invoice_id = "INV-10001"
+            return InvoiceResponse(
+                invoice_id=invoice_id,
+                total=total,
+                currency=request.currency,
+                created_at=datetime.now().isoformat(),
+                payment_link=f"https://pay.qtick.co/{invoice_id}",
+                status="created",
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/invoices", payload)
+            return InvoiceResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while creating invoice")
+            raise ServiceError("Failed to create invoice", cause=exc)

--- a/app/services/leads.py
+++ b/app/services/leads.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from app.clients.java import JavaServiceClient
+from app.schemas.lead import LeadCreateRequest, LeadCreateResponse
+from app.services.exceptions import ServiceError
+
+logger = logging.getLogger(__name__)
+
+
+class LeadService:
+    def __init__(self, client: JavaServiceClient) -> None:
+        self._client = client
+
+    async def create(self, request: LeadCreateRequest) -> LeadCreateResponse:
+        logger.debug("Creating lead for %s", request.name)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            return LeadCreateResponse(
+                lead_id="LEAD-90001",
+                status="new",
+                created_at=datetime.now().isoformat(),
+            )
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/leads", payload)
+            return LeadCreateResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while creating lead")
+            raise ServiceError("Failed to create lead", cause=exc)

--- a/app/tools/analytics.py
+++ b/app/tools/analytics.py
@@ -1,14 +1,19 @@
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.services import get_analytics_service
 from app.schemas.analytics import AnalyticsRequest, AnalyticsResponse
+from app.services import AnalyticsService
+from app.services.exceptions import ServiceError
 
 router = APIRouter()
 
 @router.post("/report", response_model=AnalyticsResponse)
-def get_analytics(req: AnalyticsRequest):
-    # mock
-    return AnalyticsResponse(
-        footfall=42,
-        revenue="SGD 1,540",
-        report_generated_at="2025-09-05T15:03:10+08:00"
-    )
+async def get_analytics(
+    req: AnalyticsRequest,
+    service: AnalyticsService = Depends(get_analytics_service),
+):
+    try:
+        return await service.generate_report(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/appointment.py
+++ b/app/tools/appointment.py
@@ -1,42 +1,36 @@
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from app.schemas.appointment import (
-    AppointmentRequest, AppointmentResponse,
-    AppointmentListRequest, AppointmentListResponse, AppointmentSummary
+    AppointmentRequest,
+    AppointmentResponse,
+    AppointmentListRequest,
+    AppointmentListResponse,
 )
+
+from app.dependencies.services import get_appointment_service
+from app.services import AppointmentService
+from app.services.exceptions import ServiceError
 
 router = APIRouter()
 
+
 @router.post("/book", response_model=AppointmentResponse)
-def book_appointment(req: AppointmentRequest):
-    # Mock booking
-    return AppointmentResponse(
-        status="confirmed",
-        appointment_id="APT-33451",
-        queue_number="B17"
-    )
+async def book_appointment(
+    req: AppointmentRequest,
+    service: AppointmentService = Depends(get_appointment_service),
+):
+    try:
+        return await service.book(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
 
 @router.post("/list", response_model=AppointmentListResponse)
-def list_appointments(req: AppointmentListRequest):
-    # Mock dataset
-    items = [
-        AppointmentSummary(
-            appointment_id="APT-33451",
-            customer_name="Alex",
-            service_id="haircut",
-            datetime="2025-09-06T17:00:00+08:00",
-            status="confirmed",
-            queue_number="B17"
-        ),
-        AppointmentSummary(
-            appointment_id="APT-33452",
-            customer_name="Jane",
-            service_id="facial",
-            datetime="2025-09-06T18:30:00+08:00",
-            status="pending",
-            queue_number=None
-        ),
-    ]
-    start = (req.page - 1) * req.page_size
-    end = start + req.page_size
-    return AppointmentListResponse(total=len(items), page=req.page, page_size=req.page_size, items=items[start:end])
+async def list_appointments(
+    req: AppointmentListRequest,
+    service: AppointmentService = Depends(get_appointment_service),
+):
+    try:
+        return await service.list(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/campaign.py
+++ b/app/tools/campaign.py
@@ -1,13 +1,19 @@
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.services import get_campaign_service
 from app.schemas.campaign import CampaignRequest, CampaignResponse
+from app.services import CampaignService
+from app.services.exceptions import ServiceError
 
 router = APIRouter()
 
 @router.post("/sendWhatsApp", response_model=CampaignResponse)
-def send_whatsapp(req: CampaignRequest):
-    # mock
-    return CampaignResponse(
-        status="sent",
-        delivery_time="2025-09-05T15:02:03+08:00"
-    )
+async def send_whatsapp(
+    req: CampaignRequest,
+    service: CampaignService = Depends(get_campaign_service),
+):
+    try:
+        return await service.send_whatsapp(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/leads.py
+++ b/app/tools/leads.py
@@ -1,15 +1,19 @@
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.services import get_lead_service
 from app.schemas.lead import LeadCreateRequest, LeadCreateResponse
-from datetime import datetime
+from app.services import LeadService
+from app.services.exceptions import ServiceError
 
 router = APIRouter()
 
 @router.post("/create", response_model=LeadCreateResponse)
-def create_lead(req: LeadCreateRequest):
-    # mock
-    return LeadCreateResponse(
-        lead_id="LEAD-90001",
-        status="new",
-        created_at=datetime.now().isoformat()
-    )
+async def create_lead(
+    req: LeadCreateRequest,
+    service: LeadService = Depends(get_lead_service),
+):
+    try:
+        return await service.create(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/langchain_tools/qtick.py
+++ b/langchain_tools/qtick.py
@@ -1,5 +1,6 @@
 
 from typing import List, Optional
+import os
 import requests
 from pydantic import BaseModel, Field, validator
 from datetime import datetime, timedelta
@@ -8,7 +9,15 @@ import re
 from zoneinfo import ZoneInfo
 from langchain.tools import StructuredTool
 
-MCP_BASE = "http://localhost:8000"
+MCP_BASE = os.getenv("QTICK_MCP_BASE_URL", "http://localhost:8000")
+
+
+def configure(*, base_url: Optional[str] = None) -> None:
+    """Configure the MCP base URL used by the LangChain tools."""
+
+    global MCP_BASE
+    if base_url:
+        MCP_BASE = base_url.rstrip("/")
 
 # ---------- Appointment Book ----------
 class BookAppointmentInput(BaseModel):
@@ -252,4 +261,5 @@ __all__ = [
     "campaign_tool",
     "analytics_tool",
     "datetime_tool",
+    "configure",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 fastapi
 uvicorn
 pydantic
+httpx
 requests
 dateparser
 tzdata


### PR DESCRIPTION
## Summary
- add configuration settings, Java client, and service layer to prepare for downstream integration
- update FastAPI routers to use async service calls with consistent error handling
- rework agent bootstrap to respect configured MCP base URL and LangChain tool cache

## Testing
- `pytest` *(fails: missing openai dependency for upstream tests)*

------
https://chatgpt.com/codex/tasks/task_b_68cac231a594832e8bb865479f96839f