### PR TITLE
Prevent circular import when loading services

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,8 +1,18 @@
-from .appointment import AppointmentService
-from .analytics import AnalyticsService
-from .campaign import CampaignService
-from .invoice import InvoiceService
-from .leads import LeadService
+"""Service package public API definitions.
+
+This module previously imported each service implementation eagerly at
+import-time. When the HTTP client attempted to import
+``app.services.exceptions`` the interpreter first executed this module, which
+in turn imported the service implementations. Those implementations depend on
+``app.clients.java`` and therefore triggered a circular import during
+application start up. To avoid that situation we lazily import the service
+implementations only when they are accessed.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "AppointmentService",
@@ -11,3 +21,30 @@ __all__ = [
     "InvoiceService",
     "LeadService",
 ]
+
+_SERVICE_MODULES = {
+    "AppointmentService": "appointment",
+    "AnalyticsService": "analytics",
+    "CampaignService": "campaign",
+    "InvoiceService": "invoice",
+    "LeadService": "leads",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _SERVICE_MODULES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(f".{_SERVICE_MODULES[name]}", __name__)
+    attr = getattr(module, name)
+    globals()[name] = attr
+    return attr
+
+
+if TYPE_CHECKING:  # pragma: no cover - import for static analysis only
+    from .analytics import AnalyticsService as AnalyticsService
+    from .appointment import AppointmentService as AppointmentService
+    from .campaign import CampaignService as CampaignService
+    from .invoice import InvoiceService as InvoiceService
+    from .leads import LeadService as LeadService
+


### PR DESCRIPTION
## Summary
- switch the `app.services` package to lazily import its service implementations
- add explanatory module documentation and type-checking imports to preserve editor support

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cac96b1ef8832ea559c64f010619e4