### PR TITLE
Respect runtime environment for MCP base URL defaults

### DIFF
--- a/langchain_tools/qtick.py
+++ b/langchain_tools/qtick.py
@@ -1,15 +1,28 @@
 
-from typing import List, Optional
 import os
-import requests
-from pydantic import BaseModel, Field, validator
 from datetime import datetime, timedelta
-import dateparser
 import re
-from zoneinfo import ZoneInfo
-from langchain.tools import StructuredTool
+from typing import List, Optional
 
-MCP_BASE = os.getenv("QTICK_MCP_BASE_URL", "http://localhost:8000")
+import dateparser
+import requests
+from langchain.tools import StructuredTool
+from pydantic import BaseModel, Field, validator
+from zoneinfo import ZoneInfo
+
+from app.config import runtime_default_mcp_base_url
+
+
+def _resolve_mcp_base_url() -> str:
+    """Return the MCP base URL honouring explicit overrides when present."""
+
+    base = os.getenv("QTICK_MCP_BASE_URL")
+    if base:
+        return base.rstrip("/")
+    return runtime_default_mcp_base_url()
+
+
+MCP_BASE = _resolve_mcp_base_url()
 
 
 def configure(*, base_url: Optional[str] = None) -> None:

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 import threading
@@ -53,3 +54,60 @@ def test_agent_run_endpoint_uses_background_thread(monkeypatch):
     assert agent.thread_ident is not None
     assert loop_thread_ident is not None
     assert agent.thread_ident != loop_thread_ident
+
+
+def test_agent_config_uses_runtime_port_default(monkeypatch):
+    monkeypatch.delenv("QTICK_MCP_BASE_URL", raising=False)
+    monkeypatch.delenv("MCP_BASE_URL", raising=False)
+    monkeypatch.delenv("RENDER_EXTERNAL_URL", raising=False)
+    monkeypatch.setenv("PORT", "10000")
+    monkeypatch.setenv("QTICK_GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+
+    import app.config as config_module
+    import langchain_tools.qtick as qtick_module
+    import app.tools.agent as agent_mod
+
+    config_module = importlib.reload(config_module)
+    qtick_module = importlib.reload(qtick_module)
+    agent_mod = importlib.reload(agent_mod)
+
+    assert qtick_module.MCP_BASE == "http://127.0.0.1:10000"
+
+    captured = {}
+    real_configure = agent_mod.configure
+
+    def spy_configure(*, base_url: str) -> None:
+        captured["base_url"] = base_url
+        real_configure(base_url=base_url)
+
+    monkeypatch.setattr(agent_mod, "configure", spy_configure)
+    monkeypatch.setattr(agent_mod, "ChatGoogleGenerativeAI", lambda **_: object())
+    monkeypatch.setattr(agent_mod, "initialize_agent", lambda **_: object())
+
+    config_module.get_settings.cache_clear()
+    agent_mod._get_agent_bundle.cache_clear()
+
+    settings = config_module.Settings()
+    agent_mod._get_agent(settings)
+
+    assert captured["base_url"].startswith("http://127.0.0.1:10000")
+    assert qtick_module.MCP_BASE == "http://127.0.0.1:10000"
+
+
+def test_agent_config_local_default(monkeypatch):
+    monkeypatch.delenv("QTICK_MCP_BASE_URL", raising=False)
+    monkeypatch.delenv("MCP_BASE_URL", raising=False)
+    monkeypatch.delenv("RENDER_EXTERNAL_URL", raising=False)
+    monkeypatch.delenv("PORT", raising=False)
+    monkeypatch.delenv("QTICK_RUNTIME_HOST", raising=False)
+    monkeypatch.delenv("QTICK_RUNTIME_SCHEME", raising=False)
+
+    import app.config as config_module
+    import langchain_tools.qtick as qtick_module
+
+    config_module = importlib.reload(config_module)
+    qtick_module = importlib.reload(qtick_module)
+
+    assert config_module.runtime_default_mcp_base_url() == "http://localhost:8000"
+    assert qtick_module.MCP_BASE == "http://localhost:8000"


### PR DESCRIPTION
## Summary
- add regression coverage to confirm the runtime-aware MCP base URL keeps the localhost fallback when no deployment variables are present

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd676cc6d4832e86fb77547d79c9bd