### PR TITLE
Refine mock repositories with collections and lookups

### DIFF
--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -5,23 +5,30 @@ import logging
 from app.clients.java import JavaServiceClient
 from app.schemas.analytics import AnalyticsRequest, AnalyticsResponse
 from app.services.exceptions import ServiceError
+from app.services.mock_store import AnalyticsRepository, get_mock_store
 
 logger = logging.getLogger(__name__)
 
 
 class AnalyticsService:
-    def __init__(self, client: JavaServiceClient) -> None:
+    def __init__(
+        self,
+        client: JavaServiceClient,
+        *,
+        repository: AnalyticsRepository | None = None,
+    ) -> None:
         self._client = client
+        self._repository = repository
+        if self._client.use_mock_data:
+            self._repository = repository or get_mock_store().analytics
 
     async def generate_report(self, request: AnalyticsRequest) -> AnalyticsResponse:
         logger.debug("Generating analytics for business %s", request.business_id)
         if self._client.use_mock_data:
             await self._client.simulate_latency()
-            return AnalyticsResponse(
-                footfall=42,
-                revenue="SGD 1,540",
-                report_generated_at="2025-09-05T15:03:10+08:00",
-            )
+            if not self._repository:
+                raise RuntimeError("Mock analytics repository not configured")
+            return await self._repository.generate_report(request)
 
         try:
             payload = request.model_dump()

--- a/app/services/campaign.py
+++ b/app/services/campaign.py
@@ -5,22 +5,30 @@ import logging
 from app.clients.java import JavaServiceClient
 from app.schemas.campaign import CampaignRequest, CampaignResponse
 from app.services.exceptions import ServiceError
+from app.services.mock_store import CampaignRepository, get_mock_store
 
 logger = logging.getLogger(__name__)
 
 
 class CampaignService:
-    def __init__(self, client: JavaServiceClient) -> None:
+    def __init__(
+        self,
+        client: JavaServiceClient,
+        *,
+        repository: CampaignRepository | None = None,
+    ) -> None:
         self._client = client
+        self._repository = repository
+        if self._client.use_mock_data:
+            self._repository = repository or get_mock_store().campaigns
 
     async def send_whatsapp(self, request: CampaignRequest) -> CampaignResponse:
         logger.debug("Sending WhatsApp campaign to %s", request.phone_number)
         if self._client.use_mock_data:
             await self._client.simulate_latency()
-            return CampaignResponse(
-                status="sent",
-                delivery_time="2025-09-05T15:02:03+08:00",
-            )
+            if not self._repository:
+                raise RuntimeError("Mock campaign repository not configured")
+            return await self._repository.send_whatsapp(request)
 
         try:
             payload = request.model_dump()

--- a/app/services/mock_store.py
+++ b/app/services/mock_store.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import itertools
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import DefaultDict, Dict, List, Optional
+
+from app.schemas.analytics import AnalyticsRequest, AnalyticsResponse
+from app.schemas.appointment import (
+    AppointmentListRequest,
+    AppointmentListResponse,
+    AppointmentRequest,
+    AppointmentResponse,
+    AppointmentSummary,
+)
+from app.schemas.billing import InvoiceRequest, InvoiceResponse
+from app.schemas.campaign import CampaignRequest, CampaignResponse
+from app.schemas.lead import LeadCreateRequest, LeadCreateResponse
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _BaseRepository:
+    def __init__(self, prefix: str) -> None:
+        self._prefix = prefix
+        self._counter = itertools.count(1)
+
+    def _next_id(self) -> str:
+        return f"{self._prefix}-{next(self._counter):05d}"
+
+
+class AppointmentRepository(_BaseRepository):
+    def __init__(self) -> None:
+        super().__init__("APT")
+        self._appointments: Dict[str, Dict[str, str]] = {}
+        self._queue_numbers: DefaultDict[str, itertools.count] = defaultdict(
+            lambda: itertools.count(1)
+        )
+
+    async def book(self, request: AppointmentRequest) -> AppointmentResponse:
+        appointment_id = self._next_id()
+        queue_number = f"B{next(self._queue_numbers[request.business_id]):02d}"
+        record = {
+            "appointment_id": appointment_id,
+            "business_id": request.business_id,
+            "customer_name": request.customer_name,
+            "service_id": request.service_id,
+            "datetime": request.datetime,
+            "status": "confirmed",
+            "queue_number": queue_number,
+        }
+        self._appointments[appointment_id] = record
+        return AppointmentResponse(
+            status="confirmed",
+            appointment_id=appointment_id,
+            queue_number=queue_number,
+        )
+
+    async def list(self, request: AppointmentListRequest) -> AppointmentListResponse:
+        filtered = [
+            AppointmentSummary(
+                appointment_id=record["appointment_id"],
+                customer_name=record["customer_name"],
+                service_id=record["service_id"],
+                datetime=record["datetime"],
+                status=record["status"],
+                queue_number=record["queue_number"],
+            )
+            for record in self._appointments.values()
+            if record["business_id"] == request.business_id
+        ]
+
+        start = (request.page - 1) * request.page_size
+        end = start + request.page_size
+        page_items = filtered[start:end]
+
+        return AppointmentListResponse(
+            total=len(filtered),
+            page=request.page,
+            page_size=request.page_size,
+            items=page_items,
+        )
+
+    async def get(self, appointment_id: str) -> Optional[Dict[str, str]]:
+        appointment = self._appointments.get(appointment_id)
+        return dict(appointment) if appointment is not None else None
+
+
+class InvoiceRepository(_BaseRepository):
+    def __init__(self) -> None:
+        super().__init__("INV")
+        self._invoices: Dict[str, Dict[str, object]] = {}
+
+    async def create(self, request: InvoiceRequest) -> InvoiceResponse:
+        total = 0.0
+        for item in request.items:
+            unit_price = getattr(item, "unit_price", None)
+            if unit_price is None:
+                unit_price = getattr(item, "price", None)
+            if unit_price is None:
+                unit_price = 0.0
+            line_total = float(item.quantity) * float(unit_price)
+            line_total *= 1.0 + float(item.tax_rate)
+            total += line_total
+        total = round(total, 2)
+
+        invoice_id = self._next_id()
+        record = {
+            "invoice_id": invoice_id,
+            "business_id": request.business_id,
+            "total": total,
+            "currency": request.currency,
+            "created_at": _utc_now_iso(),
+            "payment_link": f"https://pay.qtick.co/{invoice_id}",
+            "status": "created",
+        }
+        self._invoices[invoice_id] = record
+        return InvoiceResponse(**record)
+
+    async def list(self, business_id: Optional[str] = None) -> List[Dict[str, object]]:
+        if business_id is None:
+            return [dict(invoice) for invoice in self._invoices.values()]
+        return [
+            dict(invoice)
+            for invoice in self._invoices.values()
+            if invoice["business_id"] == business_id
+        ]
+
+    async def get(self, invoice_id: str) -> Optional[Dict[str, object]]:
+        invoice = self._invoices.get(invoice_id)
+        return dict(invoice) if invoice is not None else None
+
+
+class LeadRepository(_BaseRepository):
+    def __init__(self) -> None:
+        super().__init__("LEAD")
+        self._leads: Dict[str, Dict[str, object]] = {}
+
+    async def create(self, request: LeadCreateRequest) -> LeadCreateResponse:
+        lead_id = self._next_id()
+        record = {
+            "lead_id": lead_id,
+            "business_id": request.business_id,
+            "status": "new",
+            "created_at": _utc_now_iso(),
+            "name": request.name,
+            "phone": request.phone,
+            "email": request.email,
+            "source": request.source,
+            "notes": request.notes,
+        }
+        self._leads[lead_id] = record
+        return LeadCreateResponse(
+            lead_id=lead_id,
+            status="new",
+            created_at=record["created_at"],
+        )
+
+    async def list(self, business_id: Optional[str] = None) -> List[Dict[str, object]]:
+        if business_id is None:
+            return [dict(lead) for lead in self._leads.values()]
+        return [
+            dict(lead)
+            for lead in self._leads.values()
+            if lead["business_id"] == business_id
+        ]
+
+    async def get(self, lead_id: str) -> Optional[Dict[str, object]]:
+        lead = self._leads.get(lead_id)
+        return dict(lead) if lead is not None else None
+
+
+class CampaignRepository(_BaseRepository):
+    def __init__(self) -> None:
+        super().__init__("CMP")
+        self._campaigns: Dict[str, Dict[str, object]] = {}
+
+    async def send_whatsapp(self, request: CampaignRequest) -> CampaignResponse:
+        campaign_id = self._next_id()
+        delivery_time = _utc_now_iso()
+        record = {
+            "campaign_id": campaign_id,
+            "customer_name": request.customer_name,
+            "phone_number": request.phone_number,
+            "message_template": request.message_template,
+            "offer_code": request.offer_code,
+            "expiry": request.expiry,
+            "status": "sent",
+            "delivery_time": delivery_time,
+        }
+        self._campaigns[campaign_id] = record
+        return CampaignResponse(status="sent", delivery_time=delivery_time)
+
+    async def list(self) -> List[Dict[str, object]]:
+        return [dict(campaign) for campaign in self._campaigns.values()]
+
+    async def get(self, campaign_id: str) -> Optional[Dict[str, object]]:
+        campaign = self._campaigns.get(campaign_id)
+        return dict(campaign) if campaign is not None else None
+
+
+class AnalyticsRepository:
+    def __init__(
+        self,
+        appointment_repository: AppointmentRepository,
+        invoice_repository: InvoiceRepository,
+    ) -> None:
+        self._appointments = appointment_repository
+        self._invoices = invoice_repository
+
+    async def generate_report(self, request: AnalyticsRequest) -> AnalyticsResponse:
+        appointments = await self._appointments.list(
+            AppointmentListRequest(
+                business_id=request.business_id,
+                page=1,
+                page_size=10_000,
+            )
+        )
+        footfall = appointments.total
+
+        invoices = await self._invoices.list(request.business_id)
+        total_revenue = sum(float(invoice["total"]) for invoice in invoices)
+        revenue_display = f"SGD {total_revenue:,.2f}"
+
+        return AnalyticsResponse(
+            footfall=footfall,
+            revenue=revenue_display,
+            report_generated_at=_utc_now_iso(),
+        )
+
+
+@dataclass
+class MockDataStore:
+    appointments: AppointmentRepository
+    invoices: InvoiceRepository
+    leads: LeadRepository
+    campaigns: CampaignRepository
+    analytics: AnalyticsRepository
+
+
+_mock_store: Optional[MockDataStore] = None
+
+
+def get_mock_store() -> MockDataStore:
+    global _mock_store
+    if _mock_store is None:
+        appointments = AppointmentRepository()
+        invoices = InvoiceRepository()
+        leads = LeadRepository()
+        campaigns = CampaignRepository()
+        analytics = AnalyticsRepository(appointments, invoices)
+        _mock_store = MockDataStore(
+            appointments=appointments,
+            invoices=invoices,
+            leads=leads,
+            campaigns=campaigns,
+            analytics=analytics,
+        )
+    return _mock_store
+
+
+def reset_mock_store() -> None:
+    global _mock_store
+    _mock_store = None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.schemas.analytics import AnalyticsRequest
-from app.schemas.appointment import AppointmentRequest, AppointmentListRequest
+from app.schemas.appointment import AppointmentListRequest, AppointmentRequest
 from app.schemas.billing import InvoiceRequest, LineItem
 from app.schemas.campaign import CampaignRequest
 from app.schemas.lead import LeadCreateRequest
@@ -17,6 +17,14 @@ from app.services.appointment import AppointmentService
 from app.services.campaign import CampaignService
 from app.services.invoice import InvoiceService
 from app.services.leads import LeadService
+from app.services.mock_store import get_mock_store, reset_mock_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_store() -> None:
+    reset_mock_store()
+    yield
+    reset_mock_store()
 
 
 class MockLatencyClient:
@@ -30,47 +38,148 @@ class MockLatencyClient:
         self.latency_called = True
 
 
-def test_appointment_service_book_mock_data_returns_static_response():
+def test_mock_appointment_service_persists_records() -> None:
     client = MockLatencyClient()
     service = AppointmentService(client)
 
-    request = AppointmentRequest(
+    first_request = AppointmentRequest(
         business_id="biz-123",
         customer_name="Jamie",
         service_id="svc-haircut",
         datetime="2025-09-06T17:00:00+08:00",
     )
-
-    response = asyncio.run(service.book(request))
-
-    assert client.latency_called is True
-    assert response.status == "confirmed"
-    assert response.appointment_id == "APT-33451"
-    assert response.queue_number == "B17"
-
-
-def test_appointment_service_list_mock_data_paginates_items():
-    client = MockLatencyClient()
-    service = AppointmentService(client)
-
-    request = AppointmentListRequest(
+    second_request = AppointmentRequest(
         business_id="biz-123",
-        page=2,
-        page_size=1,
+        customer_name="Alex",
+        service_id="svc-facial",
+        datetime="2025-09-06T18:30:00+08:00",
     )
 
-    response = asyncio.run(service.list(request))
+    first_response = asyncio.run(service.book(first_request))
+    second_response = asyncio.run(service.book(second_request))
 
     assert client.latency_called is True
-    assert response.total == 2
-    assert response.page == 2
-    assert response.page_size == 1
-    assert len(response.items) == 1
-    assert response.items[0].appointment_id == "APT-33452"
-    assert response.items[0].status == "pending"
+    assert first_response.appointment_id.startswith("APT-")
+    assert first_response.queue_number == "B01"
+    assert second_response.queue_number == "B02"
+
+    list_request = AppointmentListRequest(business_id="biz-123", page=1, page_size=10)
+    list_response = asyncio.run(service.list(list_request))
+
+    assert list_response.total == 2
+    assert len(list_response.items) == 2
+    assert {item.customer_name for item in list_response.items} == {"Jamie", "Alex"}
+
+    store = get_mock_store()
+    stored_first = asyncio.run(store.appointments.get(first_response.appointment_id))
+    stored_second = asyncio.run(store.appointments.get(second_response.appointment_id))
+
+    assert stored_first and stored_first["customer_name"] == "Jamie"
+    assert stored_second and stored_second["customer_name"] == "Alex"
 
 
-def test_appointment_service_book_real_mode_invokes_client_post():
+def test_mock_invoice_and_analytics_use_shared_store() -> None:
+    client = MockLatencyClient()
+    appointments = AppointmentService(client)
+    invoices = InvoiceService(client)
+    analytics = AnalyticsService(client)
+
+    business_id = "biz-analytics"
+
+    asyncio.run(
+        appointments.book(
+            AppointmentRequest(
+                business_id=business_id,
+                customer_name="Taylor",
+                service_id="svc-cut",
+                datetime="2025-09-07T11:00:00+08:00",
+            )
+        )
+    )
+    asyncio.run(
+        appointments.book(
+            AppointmentRequest(
+                business_id=business_id,
+                customer_name="Jordan",
+                service_id="svc-spa",
+                datetime="2025-09-07T12:30:00+08:00",
+            )
+        )
+    )
+
+    invoice_request = InvoiceRequest(
+        business_id=business_id,
+        customer_name="Taylor",
+        items=[
+            LineItem(description="Haircut", quantity=2, unit_price=30.0, tax_rate=0.08),
+            LineItem(description="Facial", quantity=1, price=100.0),
+        ],
+        currency="SGD",
+    )
+    invoice_response = asyncio.run(invoices.create(invoice_request))
+
+    assert invoice_response.invoice_id.startswith("INV-")
+    assert invoice_response.total == pytest.approx(164.8)
+
+    store = get_mock_store()
+    stored_invoice = asyncio.run(store.invoices.get(invoice_response.invoice_id))
+    assert stored_invoice and stored_invoice["total"] == pytest.approx(164.8)
+
+    analytics_request = AnalyticsRequest(
+        business_id=business_id,
+        metrics=["footfall", "revenue"],
+        period="weekly",
+    )
+    analytics_response = asyncio.run(analytics.generate_report(analytics_request))
+
+    assert analytics_response.footfall == 2
+    assert analytics_response.revenue == "SGD 164.80"
+
+
+def test_lead_repository_stores_created_leads() -> None:
+    client = MockLatencyClient()
+    service = LeadService(client)
+
+    request = LeadCreateRequest(business_id="biz-555", name="Morgan", email="m@example.com")
+    response = asyncio.run(service.create(request))
+
+    assert response.lead_id.startswith("LEAD-")
+
+    store = get_mock_store()
+    stored = asyncio.run(store.leads.get(response.lead_id))
+    assert stored and stored["email"] == "m@example.com"
+
+    leads = asyncio.run(store.leads.list("biz-555"))
+    assert len(leads) == 1
+    assert leads[0]["lead_id"] == response.lead_id
+    assert leads[0]["email"] == "m@example.com"
+
+
+def test_campaign_repository_tracks_sent_messages() -> None:
+    client = MockLatencyClient()
+    service = CampaignService(client)
+
+    request = CampaignRequest(
+        customer_name="Sam",
+        phone_number="12345678",
+        message_template="Hello {name}",
+        offer_code="OFFER1",
+        expiry="2025-09-07",
+    )
+
+    response = asyncio.run(service.send_whatsapp(request))
+
+    assert response.status == "sent"
+
+    store = get_mock_store()
+    campaigns = asyncio.run(store.campaigns.list())
+    assert len(campaigns) == 1
+    assert campaigns[0]["phone_number"] == "12345678"
+    stored = asyncio.run(store.campaigns.get(campaigns[0]["campaign_id"]))
+    assert stored and stored["offer_code"] == "OFFER1"
+
+
+def test_appointment_service_book_real_mode_invokes_client_post() -> None:
     request = AppointmentRequest(
         business_id="biz-999",
         customer_name="Alex",
@@ -101,31 +210,7 @@ def test_appointment_service_book_real_mode_invokes_client_post():
     assert response.queue_number == "A1"
 
 
-def test_invoice_service_mock_data_computes_totals_with_tax():
-    client = MockLatencyClient()
-    service = InvoiceService(client)
-
-    request = InvoiceRequest(
-        business_id="biz-123",
-        customer_name="Jamie",
-        items=[
-            LineItem(description="Haircut", quantity=2, unit_price=30.0, tax_rate=0.08),
-            LineItem(description="Facial", quantity=1, price=100.0),
-        ],
-        currency="SGD",
-    )
-
-    response = asyncio.run(service.create(request))
-
-    assert client.latency_called is True
-    assert response.invoice_id == "INV-10001"
-    assert response.total == pytest.approx(164.8)
-    assert response.currency == "SGD"
-    assert response.payment_link.endswith("/INV-10001")
-    assert response.status == "created"
-
-
-def test_invoice_service_real_mode_invokes_client_post():
+def test_invoice_service_real_mode_invokes_client_post() -> None:
     request = InvoiceRequest(
         business_id="biz-321",
         customer_name="Taylor",
@@ -158,53 +243,7 @@ def test_invoice_service_real_mode_invokes_client_post():
     assert response.payment_link == "https://pay.qtick.co/INV-20002"
 
 
-def test_lead_service_mock_data_returns_static_lead():
-    client = MockLatencyClient()
-    service = LeadService(client)
-
-    request = LeadCreateRequest(business_id="biz-123", name="Morgan")
-
-    response = asyncio.run(service.create(request))
-
-    assert client.latency_called is True
-    assert response.lead_id == "LEAD-90001"
-    assert response.status == "new"
-
-
-def test_campaign_service_mock_data_returns_delivery_time():
-    client = MockLatencyClient()
-    service = CampaignService(client)
-
-    request = CampaignRequest(
-        customer_name="Sam",
-        phone_number="12345678",
-        message_template="Hello {name}",
-        offer_code="OFFER1",
-        expiry="2025-09-07",
-    )
-
-    response = asyncio.run(service.send_whatsapp(request))
-
-    assert client.latency_called is True
-    assert response.status == "sent"
-    assert response.delivery_time.endswith("+08:00")
-
-
-def test_analytics_service_mock_data_returns_summary():
-    client = MockLatencyClient()
-    service = AnalyticsService(client)
-
-    request = AnalyticsRequest(business_id="biz-123", metrics=["footfall"], period="weekly")
-
-    response = asyncio.run(service.generate_report(request))
-
-    assert client.latency_called is True
-    assert response.footfall == 42
-    assert response.revenue.startswith("SGD ")
-    assert response.report_generated_at.endswith("+08:00")
-
-
-def test_analytics_service_real_mode_invokes_client_post():
+def test_analytics_service_real_mode_invokes_client_post() -> None:
     request = AnalyticsRequest(business_id="biz-567", metrics=["revenue"], period="monthly")
 
     payload = {


### PR DESCRIPTION
## Summary
- store mock appointments, invoices, leads, and campaigns in keyed collections that support lookup by identifier
- expose asynchronous get helpers on each repository to retrieve stored records safely
- expand service tests to verify both listing behavior and direct repository lookups when mock mode is active

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cecc718364832e84ba2561549baf4f