### PR TITLE
Add business master data tools and listing endpoints

### DIFF
--- a/app/dependencies/services.py
+++ b/app/dependencies/services.py
@@ -9,6 +9,7 @@ from app.config import Settings, get_settings
 from app.services import (
     AnalyticsService,
     AppointmentService,
+    BusinessDirectoryService,
     CampaignService,
     InvoiceService,
     LeadService,
@@ -57,3 +58,9 @@ def get_analytics_service(
     client: JavaServiceClient = Depends(get_java_client),
 ) -> AnalyticsService:
     return AnalyticsService(client)
+
+
+def get_business_directory_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> BusinessDirectoryService:
+    return BusinessDirectoryService(client)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.dependencies.services import get_java_client_cached
 from app.tools.analytics import router as analytics_router
 from app.tools.agent import router as agent_router
 from app.tools.appointment import router as appointment_router
+from app.tools.business import router as business_router
 from app.tools.campaign import router as campaign_router
 from app.tools.invoice import router as invoice_router
 from app.tools.leads import router as leads_router
@@ -44,6 +45,7 @@ app.add_middleware(
 )
 
 app.include_router(appointment_router, prefix="/tools/appointment")
+app.include_router(business_router, prefix="/tools/business")
 app.include_router(campaign_router, prefix="/tools/campaign")
 app.include_router(analytics_router, prefix="/tools/analytics")
 app.include_router(invoice_router, prefix="/tools/invoice")

--- a/app/schemas/appointment.py
+++ b/app/schemas/appointment.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 class AppointmentRequest(BaseModel):
     business_id: str
     customer_name: str
-    service_id: str
+    service_id: int
     datetime: str
 
 class AppointmentResponse(BaseModel):
@@ -24,7 +24,7 @@ class AppointmentListRequest(BaseModel):
 class AppointmentSummary(BaseModel):
     appointment_id: str
     customer_name: str
-    service_id: str
+    service_id: int
     datetime: str
     status: str
     queue_number: Optional[str] = None

--- a/app/schemas/billing.py
+++ b/app/schemas/billing.py
@@ -1,6 +1,7 @@
 
-from pydantic import BaseModel
 from typing import List, Optional
+
+from pydantic import BaseModel
 
 class LineItem(BaseModel):
     item_id: Optional[str] = None
@@ -25,3 +26,20 @@ class InvoiceResponse(BaseModel):
     created_at: str
     payment_link: Optional[str] = None
     status: str
+
+
+class InvoiceSummary(BaseModel):
+    invoice_id: str
+    total: float
+    currency: str
+    created_at: str
+    status: str
+
+
+class InvoiceListRequest(BaseModel):
+    business_id: str
+
+
+class InvoiceListResponse(BaseModel):
+    total: int
+    items: List[InvoiceSummary]

--- a/app/schemas/business.py
+++ b/app/schemas/business.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class BusinessSummary(BaseModel):
+    """Lightweight projection of a business in the directory."""
+
+    business_id: str
+    name: str
+    location: Optional[str] = None
+    tags: List[str] = []
+
+
+class BusinessSearchRequest(BaseModel):
+    query: str = Field(..., min_length=1, description="Text fragment to search for")
+    limit: int = Field(10, ge=1, le=25, description="Maximum number of businesses to return")
+
+
+class BusinessSearchResponse(BaseModel):
+    query: str
+    total: int
+    items: List[BusinessSummary]
+
+
+class ServiceSummary(BaseModel):
+    service_id: int
+    name: str
+    category: Optional[str] = None
+    duration_minutes: Optional[int] = None
+    price: Optional[float] = None
+
+
+class ServiceLookupRequest(BaseModel):
+    service_name: str = Field(..., min_length=1, description="Service name or keyword")
+    business_id: Optional[str] = Field(None, description="Exact business identifier")
+    business_name: Optional[str] = Field(None, description="Business name fragment when id is unknown")
+    limit: int = Field(5, ge=1, le=20, description="Maximum number of services to return")
+
+    @model_validator(mode="after")
+    def validate_business_selector(cls, values: "ServiceLookupRequest") -> "ServiceLookupRequest":
+        if not values.business_id and not values.business_name:
+            raise ValueError("Either business_id or business_name must be provided")
+        return values
+
+
+class ServiceLookupResponse(BaseModel):
+    query: str
+    business: BusinessSummary
+    matches: List[ServiceSummary]
+    exact_match: Optional[ServiceSummary] = None
+    message: Optional[str] = None

--- a/app/schemas/lead.py
+++ b/app/schemas/lead.py
@@ -1,6 +1,7 @@
 
-from pydantic import BaseModel
-from typing import Optional
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
 
 class LeadCreateRequest(BaseModel):
     business_id: str
@@ -14,3 +15,24 @@ class LeadCreateResponse(BaseModel):
     lead_id: str
     status: str
     created_at: str
+    next_action: str
+    follow_up_required: bool = Field(default=True)
+
+
+class LeadSummary(BaseModel):
+    lead_id: str
+    name: str
+    status: str
+    created_at: str
+    phone: Optional[str] = None
+    email: Optional[str] = None
+    source: Optional[str] = None
+
+
+class LeadListRequest(BaseModel):
+    business_id: str
+
+
+class LeadListResponse(BaseModel):
+    total: int
+    items: List[LeadSummary]

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "CampaignService",
     "InvoiceService",
     "LeadService",
+    "BusinessDirectoryService",
 ]
 
 _SERVICE_MODULES = {
@@ -28,6 +29,7 @@ _SERVICE_MODULES = {
     "CampaignService": "campaign",
     "InvoiceService": "invoice",
     "LeadService": "leads",
+    "BusinessDirectoryService": "business",
 }
 
 
@@ -44,6 +46,7 @@ def __getattr__(name: str) -> Any:
 if TYPE_CHECKING:  # pragma: no cover - import for static analysis only
     from .analytics import AnalyticsService as AnalyticsService
     from .appointment import AppointmentService as AppointmentService
+    from .business import BusinessDirectoryService as BusinessDirectoryService
     from .campaign import CampaignService as CampaignService
     from .invoice import InvoiceService as InvoiceService
     from .leads import LeadService as LeadService

--- a/app/services/business.py
+++ b/app/services/business.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+
+from app.clients.java import JavaServiceClient
+from app.schemas.business import (
+    BusinessSearchRequest,
+    BusinessSearchResponse,
+    BusinessSummary,
+    ServiceLookupRequest,
+    ServiceLookupResponse,
+)
+from app.services.exceptions import ServiceError
+from app.services.mock_store import MasterDataRepository, get_mock_store
+
+logger = logging.getLogger(__name__)
+
+
+class BusinessDirectoryService:
+    """Service responsible for business and service master data queries."""
+
+    def __init__(
+        self,
+        client: JavaServiceClient,
+        *,
+        repository: MasterDataRepository | None = None,
+    ) -> None:
+        self._client = client
+        self._repository = repository
+        if self._client.use_mock_data:
+            self._repository = repository or get_mock_store().master_data
+
+    async def search(self, request: BusinessSearchRequest) -> BusinessSearchResponse:
+        logger.info("Searching businesses for query '%s'", request.query)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            if not self._repository:
+                raise RuntimeError("Mock master data repository not configured")
+            return self._repository.search_businesses(request.query, request.limit)
+
+        raise ServiceError("Business search is not available in live mode yet")
+
+    async def lookup_service(
+        self, request: ServiceLookupRequest
+    ) -> ServiceLookupResponse:
+        logger.info(
+            "Looking up service '%s' for business selector (%s, %s)",
+            request.service_name,
+            request.business_id,
+            request.business_name,
+        )
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            if not self._repository:
+                raise RuntimeError("Mock master data repository not configured")
+
+            business_identifier = request.business_id or request.business_name
+            assert business_identifier is not None  # for mypy
+            business_record = self._repository.get_business(business_identifier)
+            if not business_record:
+                raise ServiceError(
+                    f"Business '{business_identifier}' not found in master data"
+                )
+
+            matches = self._repository.find_services(
+                business_record, request.service_name, request.limit
+            )
+            exact = next(
+                (match for match in matches if match.name.lower() == request.service_name.lower()),
+                None,
+            )
+
+            message: str | None = None
+            if not matches:
+                message = "No matching services were found. Try a different keyword."
+            elif len(matches) > 1 and not exact:
+                message = (
+                    "Multiple services matched your search. Please choose the most appropriate option."
+                )
+            elif len(matches) > 1 and exact:
+                message = (
+                    "Multiple services found including an exact name match; confirm the intended service."
+                )
+
+            business_summary = BusinessSummary(
+                business_id=business_record.business_id,
+                name=business_record.name,
+                location=business_record.location,
+                tags=list(business_record.tags),
+            )
+
+            return ServiceLookupResponse(
+                query=request.service_name,
+                business=business_summary,
+                matches=matches,
+                exact_match=exact,
+                message=message,
+            )
+
+        raise ServiceError("Service lookup is not available in live mode yet")

--- a/app/services/invoice.py
+++ b/app/services/invoice.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import logging
 
 from app.clients.java import JavaServiceClient
-from app.schemas.billing import InvoiceRequest, InvoiceResponse
+from app.schemas.billing import (
+    InvoiceListRequest,
+    InvoiceListResponse,
+    InvoiceRequest,
+    InvoiceResponse,
+    InvoiceSummary,
+)
 from app.services.exceptions import ServiceError
 from app.services.mock_store import InvoiceRepository, get_mock_store
 
@@ -39,3 +45,32 @@ class InvoiceService:
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Unexpected error while creating invoice")
             raise ServiceError("Failed to create invoice", cause=exc)
+
+    async def list(self, request: InvoiceListRequest) -> InvoiceListResponse:
+        logger.info("Listing invoices for business %s", request.business_id)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            if not self._repository:
+                raise RuntimeError("Mock invoice repository not configured")
+            invoices = await self._repository.list(request.business_id)
+            items = [
+                InvoiceSummary(
+                    invoice_id=invoice["invoice_id"],
+                    total=float(invoice["total"]),
+                    currency=str(invoice["currency"]),
+                    created_at=str(invoice["created_at"]),
+                    status=str(invoice["status"]),
+                )
+                for invoice in invoices
+            ]
+            return InvoiceListResponse(total=len(items), items=items)
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/invoices/list", payload)
+            return InvoiceListResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while listing invoices")
+            raise ServiceError("Failed to list invoices", cause=exc)

--- a/app/services/leads.py
+++ b/app/services/leads.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import logging
 
 from app.clients.java import JavaServiceClient
-from app.schemas.lead import LeadCreateRequest, LeadCreateResponse
+from app.schemas.lead import (
+    LeadCreateRequest,
+    LeadCreateResponse,
+    LeadListRequest,
+    LeadListResponse,
+    LeadSummary,
+)
 from app.services.exceptions import ServiceError
 from app.services.mock_store import LeadRepository, get_mock_store
 
@@ -28,14 +34,59 @@ class LeadService:
             await self._client.simulate_latency()
             if not self._repository:
                 raise RuntimeError("Mock lead repository not configured")
-            return await self._repository.create(request)
+            response = await self._repository.create(request)
+            return LeadCreateResponse(
+                lead_id=response.lead_id,
+                status=response.status,
+                created_at=response.created_at,
+                next_action="Schedule a follow-up call or message with this lead within 24 hours.",
+                follow_up_required=True,
+            )
 
         try:
             payload = request.model_dump()
             data = await self._client.post("/leads", payload)
-            return LeadCreateResponse(**data)
+            return LeadCreateResponse(
+                **data,
+                next_action=data.get(
+                    "next_action",
+                    "Schedule a follow-up call or message with this lead within 24 hours.",
+                ),
+                follow_up_required=data.get("follow_up_required", True),
+            )
         except ServiceError:
             raise
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Unexpected error while creating lead")
             raise ServiceError("Failed to create lead", cause=exc)
+
+    async def list(self, request: LeadListRequest) -> LeadListResponse:
+        logger.info("Listing leads for business %s", request.business_id)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            if not self._repository:
+                raise RuntimeError("Mock lead repository not configured")
+            leads = await self._repository.list(request.business_id)
+            summaries = [
+                LeadSummary(
+                    lead_id=lead["lead_id"],
+                    name=lead["name"],
+                    status=lead["status"],
+                    phone=lead.get("phone"),
+                    email=lead.get("email"),
+                    source=lead.get("source"),
+                    created_at=lead["created_at"],
+                )
+                for lead in leads
+            ]
+            return LeadListResponse(total=len(summaries), items=summaries)
+
+        try:
+            payload = request.model_dump()
+            data = await self._client.post("/leads/list", payload)
+            return LeadListResponse(**data)
+        except ServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unexpected error while listing leads")
+            raise ServiceError("Failed to list leads", cause=exc)

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -15,13 +15,17 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langchain_tools.qtick import (
     analytics_tool,
+    business_search_tool,
+    business_service_lookup_tool,
     appointment_list_tool,
     appointment_tool,
     campaign_tool,
     configure,
     datetime_tool,
     invoice_create_tool,
+    invoice_list_tool,
     lead_create_tool,
+    lead_list_tool,
 )
 
 router = APIRouter()
@@ -34,10 +38,14 @@ def _cache_key(settings: Settings) -> Tuple[str, str, float]:
 def _build_tools() -> List:
     return [
         datetime_tool(),
+        business_search_tool(),
+        business_service_lookup_tool(),
         appointment_tool(),
         appointment_list_tool(),
+        invoice_list_tool(),
         invoice_create_tool(),
         lead_create_tool(),
+        lead_list_tool(),
         campaign_tool(),
         analytics_tool(),
     ]

--- a/app/tools/business.py
+++ b/app/tools/business.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.services import get_business_directory_service
+from app.schemas.business import (
+    BusinessSearchRequest,
+    BusinessSearchResponse,
+    ServiceLookupRequest,
+    ServiceLookupResponse,
+)
+from app.services.business import BusinessDirectoryService
+from app.services.exceptions import ServiceError
+
+router = APIRouter()
+
+
+@router.post("/search", response_model=BusinessSearchResponse)
+async def search_businesses(
+    req: BusinessSearchRequest,
+    service: BusinessDirectoryService = Depends(get_business_directory_service),
+):
+    try:
+        return await service.search(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.post("/services/find", response_model=ServiceLookupResponse)
+async def find_service(
+    req: ServiceLookupRequest,
+    service: BusinessDirectoryService = Depends(get_business_directory_service),
+):
+    try:
+        return await service.lookup_service(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/invoice.py
+++ b/app/tools/invoice.py
@@ -2,7 +2,12 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.dependencies.services import get_invoice_service
-from app.schemas.billing import InvoiceRequest, InvoiceResponse
+from app.schemas.billing import (
+    InvoiceListRequest,
+    InvoiceListResponse,
+    InvoiceRequest,
+    InvoiceResponse,
+)
 from app.services import InvoiceService
 from app.services.exceptions import ServiceError
 
@@ -15,5 +20,16 @@ async def create_invoice(
 ):
     try:
         return await service.create(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.post("/list", response_model=InvoiceListResponse)
+async def list_invoices(
+    req: InvoiceListRequest,
+    service: InvoiceService = Depends(get_invoice_service),
+):
+    try:
+        return await service.list(req)
     except ServiceError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/leads.py
+++ b/app/tools/leads.py
@@ -2,7 +2,12 @@
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.dependencies.services import get_lead_service
-from app.schemas.lead import LeadCreateRequest, LeadCreateResponse
+from app.schemas.lead import (
+    LeadCreateRequest,
+    LeadCreateResponse,
+    LeadListRequest,
+    LeadListResponse,
+)
 from app.services import LeadService
 from app.services.exceptions import ServiceError
 
@@ -15,5 +20,16 @@ async def create_lead(
 ):
     try:
         return await service.create(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.post("/list", response_model=LeadListResponse)
+async def list_leads(
+    req: LeadListRequest,
+    service: LeadService = Depends(get_lead_service),
+):
+    try:
+        return await service.list(req)
     except ServiceError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/mcp.py
+++ b/app/tools/mcp.py
@@ -15,6 +15,32 @@ def require_api_key(x_api_key: Optional[str] = Header(None)):
 
 TOOLS: List[Dict[str, Any]] = [
     {
+        "name": "business.search",
+        "description": "Search for businesses by name, id, or tag.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 25, "default": 10},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "business.services.find",
+        "description": "Find service identifiers for a business using name keywords.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "service_name": {"type": "string"},
+                "business_id": {"type": "string"},
+                "business_name": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 20, "default": 5},
+            },
+            "required": ["service_name"],
+        },
+    },
+    {
         "name": "appointments.book",
         "description": "Book an appointment in QTick.",
         "inputSchema": {
@@ -22,7 +48,7 @@ TOOLS: List[Dict[str, Any]] = [
             "properties": {
                 "business_id": {"type":"string"},
                 "customer_name": {"type":"string"},
-                "service_id": {"type":"string"},
+                "service_id": {"type":"integer"},
                 "datetime": {"type":"string","format":"date-time"}
             },
             "required": ["business_id","customer_name","service_id","datetime"]
@@ -72,6 +98,17 @@ TOOLS: List[Dict[str, Any]] = [
         },
     },
     {
+        "name": "invoice.list",
+        "description": "List invoices for a business.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "business_id": {"type": "string"},
+            },
+            "required": ["business_id"],
+        },
+    },
+    {
         "name": "leads.create",
         "description": "Create a new customer lead.",
         "inputSchema": {
@@ -85,6 +122,17 @@ TOOLS: List[Dict[str, Any]] = [
                 "notes":{"type":"string"}
             },
             "required": ["business_id","name"]
+        },
+    },
+    {
+        "name": "leads.list",
+        "description": "List leads captured for a business.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "business_id": {"type": "string"},
+            },
+            "required": ["business_id"],
         },
     },
     {
@@ -133,10 +181,14 @@ def mcp_tools_call(call: ToolCall):
     base = _self_base()
     try:
         routes = {
+            "business.search": "/tools/business/search",
+            "business.services.find": "/tools/business/services/find",
             "appointments.book": "/tools/appointment/book",
             "appointments.list": "/tools/appointment/list",
             "invoice.create": "/tools/invoice/create",
+            "invoice.list": "/tools/invoice/list",
             "leads.create": "/tools/leads/create",
+            "leads.list": "/tools/leads/list",
             "campaign.send_whatsapp": "/tools/campaign/sendWhatsApp",
             "analytics.report": "/tools/analytics/report",
         }


### PR DESCRIPTION
## Summary
- add a mock master data repository for Chillbreeze locations with seeded appointments and a business directory service
- extend billing and lead schemas/services with list APIs, follow-up guidance, and numeric service identifiers
- expose business search/service lookup plus invoice and lead listing tools, updating LangChain integrations and tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cf4ba8fb1c832ea4b307a4a086f828