### PR TITLE
Allow service lookup without business filter

### DIFF
--- a/langchain_tools/qtick.py
+++ b/langchain_tools/qtick.py
@@ -1,9 +1,12 @@
 
 import os
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 from typing import List, Optional
 
+import dateparser
 import requests
+from zoneinfo import ZoneInfo
 from langchain.tools import StructuredTool
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -57,12 +60,6 @@ class ServiceLookupInput(BaseModel):
     business_id: Optional[str] = None
     business_name: Optional[str] = None
     limit: int = Field(default=5, ge=1, le=20)
-
-    @model_validator(mode="after")
-    def ensure_business_selector(cls, model: "ServiceLookupInput") -> "ServiceLookupInput":
-        if not model.business_id and not model.business_name:
-            raise ValueError("Either business_id or business_name must be provided")
-        return model
 
 
 def _service_lookup(

--- a/tests/test_langchain_tools.py
+++ b/tests/test_langchain_tools.py
@@ -1,0 +1,9 @@
+from langchain_tools.qtick import ServiceLookupInput
+
+
+def test_service_lookup_input_allows_missing_business_filters():
+    payload = ServiceLookupInput(service_name="babyhaircut")
+
+    assert payload.business_id is None
+    assert payload.business_name is None
+    assert payload.limit == 5


### PR DESCRIPTION
## Summary
- remove the hard requirement for business identifiers from ServiceLookupInput so the tool can run with only a service keyword
- add a regression test to ensure bare service-name payloads are accepted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cf7d009140832eae4c66b806da0393