### PR TITLE
Add HTML view for mock data store

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from app.config import get_settings
 from app.dependencies.services import get_java_client_cached
 
 # Import routers directly from submodules (safer under reload)
+from app.mock_data_view import router as mock_data_router
 from app.tools.analytics import router as analytics_router
 from app.tools.agent import router as agent_router
 from app.tools.appointment import router as appointment_router
@@ -16,7 +17,6 @@ from app.tools.campaign import router as campaign_router
 from app.tools.invoice import router as invoice_router
 from app.tools.leads import router as leads_router
 from app.tools.mcp import router as mcp_router
-from app.tools.agent import router as agent_router
 from app.mcp_server import mcp
 from starlette.routing import Mount
 from app.health import router as health_router 
@@ -52,7 +52,8 @@ app.include_router(invoice_router, prefix="/tools/invoice")
 app.include_router(leads_router, prefix="/tools/leads")
 app.include_router(agent_router, prefix="/agent")
 app.include_router(mcp_router)  # Exposes /tools/list and /tools/call
-app.include_router(health_router)    
+app.include_router(health_router)
+app.include_router(mock_data_router)
 app.mount("/mcp", mcp.streamable_http_app()) # Mount the MCP Streamable HTTP server at /mcp
 #app.mount("/sse", mcp.sse_app()) # add this line for local testing with the Anthropic MCP client:
 

--- a/app/mock_data_view.py
+++ b/app/mock_data_view.py
@@ -1,0 +1,128 @@
+"""Routes for browsing mock data stored by the in-memory repositories."""
+from __future__ import annotations
+
+import html
+import json
+from typing import Any, Dict, Iterable, List, Mapping
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+from app.services.mock_store import BusinessRecord, ServiceRecord, get_mock_store
+
+router = APIRouter()
+
+
+def _stringify(value: Any) -> str:
+    """Return a JSON-friendly string representation for table cells."""
+    if value is None:
+        return ""
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
+    return json.dumps(value, default=str)
+
+
+def _build_table(title: str, rows: Iterable[Mapping[str, Any]]) -> str:
+    row_list: List[Dict[str, Any]] = [dict(row) for row in rows]
+    section_parts = [f"<section><h2>{html.escape(title)}</h2>"]
+    if not row_list:
+        section_parts.append("<p>No records found.</p></section>")
+        return "".join(section_parts)
+
+    columns: List[str] = []
+    for row in row_list:
+        for key in row.keys():
+            if key not in columns:
+                columns.append(key)
+
+    header = "".join(f"<th>{html.escape(column)}</th>" for column in columns)
+    body_rows: List[str] = []
+    for row in row_list:
+        cells = []
+        for column in columns:
+            value = _stringify(row.get(column))
+            cells.append(f"<td>{html.escape(value)}</td>")
+        body_rows.append("<tr>" + "".join(cells) + "</tr>")
+    table_html = (
+        "<table><thead><tr>"
+        + header
+        + "</tr></thead><tbody>"
+        + "".join(body_rows)
+        + "</tbody></table>"
+    )
+    section_parts.append(table_html)
+    section_parts.append("</section>")
+    return "".join(section_parts)
+
+
+def _business_rows(businesses: Iterable[BusinessRecord]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for business in businesses:
+        rows.append(
+            {
+                "business_id": business.business_id,
+                "name": business.name,
+                "location": business.location,
+                "tags": list(business.tags),
+            }
+        )
+    return rows
+
+
+def _service_rows(businesses: Iterable[BusinessRecord]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for business in businesses:
+        for service in business.services:
+            rows.append(_service_to_row(business.business_id, service))
+    return rows
+
+
+def _service_to_row(business_id: str, service: ServiceRecord) -> Dict[str, Any]:
+    return {
+        "business_id": business_id,
+        "service_id": service.service_id,
+        "name": service.name,
+        "category": service.category,
+        "duration_minutes": service.duration_minutes,
+        "price": service.price,
+    }
+
+
+@router.get("/mock-data", response_class=HTMLResponse)
+async def view_mock_data() -> HTMLResponse:
+    """Render all mock data from the shared in-memory store as HTML tables."""
+    store = get_mock_store()
+
+    businesses = list(store.master_data.iter_businesses())
+    sections = [
+        _build_table("Businesses", _business_rows(businesses)),
+        _build_table("Services", _service_rows(businesses)),
+        _build_table("Appointments", store.appointments._appointments.values()),
+        _build_table("Invoices", store.invoices._invoices.values()),
+        _build_table("Leads", store.leads._leads.values()),
+        _build_table("Campaigns", store.campaigns._campaigns.values()),
+    ]
+
+    sections_html = "".join(sections)
+    html_content = f"""
+    <html>
+        <head>
+            <title>Mock Data Overview</title>
+            <style>
+                body {{ font-family: Arial, sans-serif; margin: 2rem; }}
+                h1 {{ text-align: center; }}
+                section {{ margin-bottom: 2rem; }}
+                table {{ border-collapse: collapse; width: 100%; }}
+                th, td {{ border: 1px solid #ccc; padding: 0.5rem; text-align: left; }}
+                th {{ background-color: #f0f0f0; }}
+                tbody tr:nth-child(even) {{ background-color: #fafafa; }}
+            </style>
+        </head>
+        <body>
+            <h1>Mock Data Overview</h1>
+            {sections_html}
+        </body>
+    </html>
+    """
+
+    return HTMLResponse(content=html_content)

--- a/tests/test_mock_data_view.py
+++ b/tests/test_mock_data_view.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.lead import LeadCreateRequest
+from app.services.mock_store import get_mock_store, reset_mock_store
+
+
+def test_mock_data_view_renders_seed_data() -> None:
+    reset_mock_store()
+    client = TestClient(app)
+
+    response = client.get("/mock-data")
+    assert response.status_code == 200
+    body = response.text
+
+    assert "Mock Data Overview" in body
+    assert "Chillbreeze Orchard" in body  # seeded business name
+    assert "Signature Haircut" in body  # seeded service name
+    assert "No records found." in body  # empty sections show message
+
+
+def test_mock_data_view_includes_created_records() -> None:
+    reset_mock_store()
+    store = get_mock_store()
+
+    asyncio.run(
+        store.leads.create(
+            LeadCreateRequest(
+                business_id="chillbreeze",
+                name="Test Lead",
+                phone="1234567",
+                email="lead@example.com",
+                source="test",
+                notes="Follow up soon",
+            )
+        )
+    )
+
+    client = TestClient(app)
+    response = client.get("/mock-data")
+    assert response.status_code == 200
+
+    body = response.text
+    assert "Test Lead" in body
+    assert "lead@example.com" in body


### PR DESCRIPTION
## Summary
- add a new /mock-data HTML endpoint that displays mock store contents in tables
- register the router with the FastAPI app so the page is accessible in the browser
- test the page to ensure seeded and newly created records appear

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cf84eda830832ebabeea2ce3f66f5f