### PR TITLE
Add live operations feed and invoice review triggers

### DIFF
--- a/app/dependencies/services.py
+++ b/app/dependencies/services.py
@@ -13,6 +13,7 @@ from app.services import (
     CampaignService,
     InvoiceService,
     LeadService,
+    LiveOperationsService,
 )
 
 
@@ -64,3 +65,9 @@ def get_business_directory_service(
     client: JavaServiceClient = Depends(get_java_client),
 ) -> BusinessDirectoryService:
     return BusinessDirectoryService(client)
+
+
+def get_live_ops_service(
+    client: JavaServiceClient = Depends(get_java_client),
+) -> LiveOperationsService:
+    return LiveOperationsService(client)

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.tools.business import router as business_router
 from app.tools.campaign import router as campaign_router
 from app.tools.invoice import router as invoice_router
 from app.tools.leads import router as leads_router
+from app.tools.live_ops import router as live_ops_router
 from app.tools.mcp import router as mcp_router
 from app.mcp_server import mcp
 from starlette.routing import Mount
@@ -50,6 +51,7 @@ app.include_router(campaign_router, prefix="/tools/campaign")
 app.include_router(analytics_router, prefix="/tools/analytics")
 app.include_router(invoice_router, prefix="/tools/invoice")
 app.include_router(leads_router, prefix="/tools/leads")
+app.include_router(live_ops_router, prefix="/tools/live-ops")
 app.include_router(agent_router, prefix="/agent")
 app.include_router(mcp_router)  # Exposes /tools/list and /tools/call
 app.include_router(health_router)

--- a/app/schemas/billing.py
+++ b/app/schemas/billing.py
@@ -24,8 +24,11 @@ class InvoiceResponse(BaseModel):
     total: float
     currency: str
     created_at: str
+    customer_name: Optional[str] = None
     payment_link: Optional[str] = None
     status: str
+    paid_at: Optional[str] = None
+    review_request_id: Optional[str] = None
 
 
 class InvoiceSummary(BaseModel):
@@ -34,6 +37,8 @@ class InvoiceSummary(BaseModel):
     currency: str
     created_at: str
     status: str
+    customer_name: Optional[str] = None
+    paid_at: Optional[str] = None
 
 
 class InvoiceListRequest(BaseModel):
@@ -43,3 +48,8 @@ class InvoiceListRequest(BaseModel):
 class InvoiceListResponse(BaseModel):
     total: int
     items: List[InvoiceSummary]
+
+
+class InvoicePaymentRequest(BaseModel):
+    invoice_id: str
+    paid_at: Optional[str] = None

--- a/app/schemas/business.py
+++ b/app/schemas/business.py
@@ -41,14 +41,24 @@ class ServiceLookupRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_business_selector(cls, values: "ServiceLookupRequest") -> "ServiceLookupRequest":
-        if not values.business_id and not values.business_name:
-            raise ValueError("Either business_id or business_name must be provided")
+        if not values.business_id and values.business_name:
+            normalized = values.business_name.strip()
+            if not normalized:
+                raise ValueError("business_name cannot be empty when provided")
+            values.business_name = normalized
         return values
+
+
+class BusinessServiceMatch(BaseModel):
+    business: BusinessSummary
+    services: List[ServiceSummary]
 
 
 class ServiceLookupResponse(BaseModel):
     query: str
-    business: BusinessSummary
-    matches: List[ServiceSummary]
+    business: Optional[BusinessSummary] = None
+    matches: List[ServiceSummary] = Field(default_factory=list)
     exact_match: Optional[ServiceSummary] = None
     message: Optional[str] = None
+    business_candidates: Optional[List[BusinessSummary]] = None
+    service_matches: Optional[List[BusinessServiceMatch]] = None

--- a/app/schemas/live_ops.py
+++ b/app/schemas/live_ops.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from app.schemas.business import BusinessSummary
+
+
+LiveOpsEventType = Literal["appointment", "invoice", "lead", "review", "system"]
+
+
+class LiveOpsRequest(BaseModel):
+    business_id: int = Field(..., description="Target business identifier")
+    date: Optional[str] = Field(
+        None,
+        description="ISO date (YYYY-MM-DD) to summarise. Defaults to today in UTC.",
+    )
+
+
+class LiveOpsEvent(BaseModel):
+    event_type: LiveOpsEventType
+    summary: str
+    timestamp: str
+    details: Dict[str, object] = Field(default_factory=dict)
+
+
+class BusinessEventGroup(BaseModel):
+    business: BusinessSummary
+    services: List[Dict[str, object]]
+
+
+class LiveOpsResponse(BaseModel):
+    business: BusinessSummary
+    date: str
+    generated_at: str
+    total_events: int
+    events: List[LiveOpsEvent]

--- a/app/schemas/review.py
+++ b/app/schemas/review.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class ReviewRecord(BaseModel):
+    review_id: str
+    business_id: int
+    invoice_id: str
+    customer_name: str
+    status: str
+    requested_at: str
+    completed_at: Optional[str] = None
+    rating: Optional[int] = None
+    feedback: Optional[str] = None

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "InvoiceService",
     "LeadService",
     "BusinessDirectoryService",
+    "LiveOperationsService",
 ]
 
 _SERVICE_MODULES = {
@@ -30,6 +31,7 @@ _SERVICE_MODULES = {
     "InvoiceService": "invoice",
     "LeadService": "leads",
     "BusinessDirectoryService": "business",
+    "LiveOperationsService": "live_ops",
 }
 
 
@@ -47,6 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - import for static analysis only
     from .analytics import AnalyticsService as AnalyticsService
     from .appointment import AppointmentService as AppointmentService
     from .business import BusinessDirectoryService as BusinessDirectoryService
+    from .live_ops import LiveOperationsService as LiveOperationsService
     from .campaign import CampaignService as CampaignService
     from .invoice import InvoiceService as InvoiceService
     from .leads import LeadService as LeadService

--- a/app/services/live_ops.py
+++ b/app/services/live_ops.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+from typing import Iterable, List, Optional
+
+from app.clients.java import JavaServiceClient
+from app.schemas.appointment import AppointmentListRequest
+from app.schemas.business import BusinessSummary
+from app.schemas.live_ops import LiveOpsEvent, LiveOpsRequest, LiveOpsResponse
+from app.services.exceptions import ServiceError
+from app.services.mock_store import (
+    AppointmentRepository,
+    InvoiceRepository,
+    LeadRepository,
+    MasterDataRepository,
+    ReviewRepository,
+    get_mock_store,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class LiveOperationsService:
+    """Aggregate live operational events for a business."""
+
+    def __init__(
+        self,
+        client: JavaServiceClient,
+        *,
+        master_data: MasterDataRepository | None = None,
+        appointments: AppointmentRepository | None = None,
+        invoices: InvoiceRepository | None = None,
+        leads: LeadRepository | None = None,
+        reviews: ReviewRepository | None = None,
+    ) -> None:
+        self._client = client
+        self._master_data = master_data
+        self._appointments = appointments
+        self._invoices = invoices
+        self._leads = leads
+        self._reviews = reviews
+        if self._client.use_mock_data:
+            store = get_mock_store()
+            self._master_data = master_data or store.master_data
+            self._appointments = appointments or store.appointments
+            self._invoices = invoices or store.invoices
+            self._leads = leads or store.leads
+            self._reviews = reviews or store.reviews
+
+    async def events(self, request: LiveOpsRequest) -> LiveOpsResponse:
+        logger.info("Fetching live operations for business %s", request.business_id)
+        if self._client.use_mock_data:
+            await self._client.simulate_latency()
+            return await self._collect_mock_events(request)
+
+        raise ServiceError("Live operations feed is not available in live mode yet")
+
+    async def _collect_mock_events(self, request: LiveOpsRequest) -> LiveOpsResponse:
+        if not all([self._master_data, self._appointments, self._invoices, self._leads, self._reviews]):
+            raise RuntimeError("Mock repositories for live operations are not configured")
+
+        business_record = self._master_data.get_business(request.business_id)
+        if not business_record:
+            raise ServiceError(f"Business '{request.business_id}' not found")
+
+        target_date = self._resolve_target_date(request.date)
+        events: List[LiveOpsEvent] = []
+
+        appointments = await self._appointments.list(
+            AppointmentListRequest(
+                business_id=business_record.business_id,
+                page=1,
+                page_size=200,
+            )
+        )
+        events.extend(self._build_appointment_events(appointments.items, target_date))
+
+        invoice_records = await self._invoices.list(business_record.business_id)
+        events.extend(self._build_invoice_events(invoice_records, target_date))
+
+        lead_records = await self._leads.list(business_record.business_id)
+        events.extend(self._build_lead_events(lead_records, target_date))
+
+        review_records = await self._reviews.list(business_record.business_id)
+        events.extend(self._build_review_events(review_records, target_date))
+
+        events.sort(key=lambda event: event.timestamp, reverse=True)
+
+        business_summary = BusinessSummary(
+            business_id=business_record.business_id,
+            name=business_record.name,
+            location=business_record.location,
+            tags=list(business_record.tags),
+        )
+
+        return LiveOpsResponse(
+            business=business_summary,
+            date=target_date.isoformat(),
+            generated_at=_utc_now_iso(),
+            total_events=len(events),
+            events=events,
+        )
+
+    @staticmethod
+    def _resolve_target_date(value: Optional[str]) -> date:
+        if not value:
+            return datetime.now(timezone.utc).date()
+        try:
+            return datetime.fromisoformat(value).date()
+        except ValueError as exc:  # pragma: no cover - validation occurs at schema level
+            raise ServiceError("Invalid date format. Expected YYYY-MM-DD.") from exc
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            normalized = value.replace("Z", "+00:00")
+            return datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+
+    def _build_appointment_events(
+        self, appointments: Iterable, target_date: date
+    ) -> List[LiveOpsEvent]:
+        events: List[LiveOpsEvent] = []
+        for item in appointments:
+            dt = self._parse_datetime(getattr(item, "datetime", None))
+            if not dt or dt.astimezone(timezone.utc).date() != target_date:
+                continue
+            summary = f"Appointment confirmed for {item.customer_name}"
+            events.append(
+                LiveOpsEvent(
+                    event_type="appointment",
+                    summary=summary,
+                    timestamp=dt.isoformat(),
+                    details={
+                        "queue_number": getattr(item, "queue_number", None),
+                        "status": getattr(item, "status", None),
+                        "service_id": getattr(item, "service_id", None),
+                    },
+                )
+            )
+        return events
+
+    def _build_invoice_events(
+        self, invoices: Iterable[dict], target_date: date
+    ) -> List[LiveOpsEvent]:
+        events: List[LiveOpsEvent] = []
+        for invoice in invoices:
+            created_dt = self._parse_datetime(str(invoice.get("created_at")))
+            if created_dt and created_dt.astimezone(timezone.utc).date() == target_date:
+                customer = invoice.get("customer_name") or "customer"
+                summary = f"Invoice {invoice['invoice_id']} issued to {customer}"
+                events.append(
+                    LiveOpsEvent(
+                        event_type="invoice",
+                        summary=summary,
+                        timestamp=created_dt.isoformat(),
+                        details={
+                            "status": invoice.get("status"),
+                            "total": float(invoice.get("total", 0.0)),
+                            "currency": invoice.get("currency"),
+                        },
+                    )
+                )
+
+            paid_at = invoice.get("paid_at")
+            paid_dt = self._parse_datetime(str(paid_at) if paid_at else None)
+            if paid_dt and paid_dt.astimezone(timezone.utc).date() == target_date:
+                summary = f"Payment received for invoice {invoice['invoice_id']}"
+                events.append(
+                    LiveOpsEvent(
+                        event_type="invoice",
+                        summary=summary,
+                        timestamp=paid_dt.isoformat(),
+                        details={
+                            "status": "paid",
+                            "total": float(invoice.get("total", 0.0)),
+                            "currency": invoice.get("currency"),
+                        },
+                    )
+                )
+        return events
+
+    def _build_lead_events(
+        self, leads: Iterable[dict], target_date: date
+    ) -> List[LiveOpsEvent]:
+        events: List[LiveOpsEvent] = []
+        for lead in leads:
+            created_dt = self._parse_datetime(str(lead.get("created_at")))
+            if not created_dt or created_dt.astimezone(timezone.utc).date() != target_date:
+                continue
+            summary = f"New lead captured: {lead.get('name', 'Prospect')}"
+            events.append(
+                LiveOpsEvent(
+                    event_type="lead",
+                    summary=summary,
+                    timestamp=created_dt.isoformat(),
+                    details={
+                        "status": lead.get("status"),
+                        "source": lead.get("source"),
+                    },
+                )
+            )
+        return events
+
+    def _build_review_events(
+        self, reviews: Iterable[dict], target_date: date
+    ) -> List[LiveOpsEvent]:
+        events: List[LiveOpsEvent] = []
+        for review in reviews:
+            requested_dt = self._parse_datetime(str(review.get("requested_at")))
+            if requested_dt and requested_dt.astimezone(timezone.utc).date() == target_date:
+                summary = f"Review request sent to {review.get('customer_name', 'customer')}"
+                events.append(
+                    LiveOpsEvent(
+                        event_type="review",
+                        summary=summary,
+                        timestamp=requested_dt.isoformat(),
+                        details={
+                            "status": review.get("status"),
+                            "invoice_id": review.get("invoice_id"),
+                        },
+                    )
+                )
+
+            completed_dt = self._parse_datetime(str(review.get("completed_at")))
+            if (
+                completed_dt
+                and completed_dt.astimezone(timezone.utc).date() == target_date
+                and review.get("rating")
+            ):
+                summary = (
+                    f"New {review['rating']}-star review received from {review.get('customer_name', 'customer')}"
+                )
+                events.append(
+                    LiveOpsEvent(
+                        event_type="review",
+                        summary=summary,
+                        timestamp=completed_dt.isoformat(),
+                        details={
+                            "rating": review.get("rating"),
+                            "feedback": review.get("feedback"),
+                        },
+                    )
+                )
+        return events

--- a/app/tools/invoice.py
+++ b/app/tools/invoice.py
@@ -5,6 +5,7 @@ from app.dependencies.services import get_invoice_service
 from app.schemas.billing import (
     InvoiceListRequest,
     InvoiceListResponse,
+    InvoicePaymentRequest,
     InvoiceRequest,
     InvoiceResponse,
 )
@@ -31,5 +32,16 @@ async def list_invoices(
 ):
     try:
         return await service.list(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.post("/mark-paid", response_model=InvoiceResponse)
+async def mark_invoice_paid(
+    req: InvoicePaymentRequest,
+    service: InvoiceService = Depends(get_invoice_service),
+):
+    try:
+        return await service.mark_paid(req)
     except ServiceError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/live_ops.py
+++ b/app/tools/live_ops.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.services import get_live_ops_service
+from app.schemas.live_ops import LiveOpsRequest, LiveOpsResponse
+from app.services.exceptions import ServiceError
+from app.services.live_ops import LiveOperationsService
+
+router = APIRouter()
+
+
+@router.post("/events", response_model=LiveOpsResponse)
+async def live_events(
+    req: LiveOpsRequest,
+    service: LiveOperationsService = Depends(get_live_ops_service),
+):
+    try:
+        return await service.events(req)
+    except ServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/app/tools/mcp.py
+++ b/app/tools/mcp.py
@@ -109,6 +109,18 @@ TOOLS: List[Dict[str, Any]] = [
         },
     },
     {
+        "name": "invoice.mark_paid",
+        "description": "Mark an invoice as paid and trigger the post-payment review flow.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "invoice_id": {"type": "string"},
+                "paid_at": {"type": "string", "format": "date-time"},
+            },
+            "required": ["invoice_id"],
+        },
+    },
+    {
         "name": "leads.create",
         "description": "Create a new customer lead.",
         "inputSchema": {
@@ -163,6 +175,18 @@ TOOLS: List[Dict[str, Any]] = [
             "required":["business_id","metrics","period"]
         },
     },
+    {
+        "name": "live_ops.events",
+        "description": "Summarise today's key business events such as appointments, payments, leads and reviews.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "business_id": {"type": "integer"},
+                "date": {"type": "string", "format": "date"},
+            },
+            "required": ["business_id"],
+        },
+    },
 ]
 
 @router.get("/tools/list", dependencies=[Depends(require_api_key)])
@@ -187,10 +211,12 @@ def mcp_tools_call(call: ToolCall):
             "appointments.list": "/tools/appointment/list",
             "invoice.create": "/tools/invoice/create",
             "invoice.list": "/tools/invoice/list",
+            "invoice.mark_paid": "/tools/invoice/mark-paid",
             "leads.create": "/tools/leads/create",
             "leads.list": "/tools/leads/list",
             "campaign.send_whatsapp": "/tools/campaign/sendWhatsApp",
             "analytics.report": "/tools/analytics/report",
+            "live_ops.events": "/tools/live-ops/events",
         }
         if call.name not in routes:
             raise HTTPException(status_code=404, detail=f"Unknown tool: {call.name}")


### PR DESCRIPTION
## Summary
- introduce live operations schemas, service, and FastAPI endpoint to surface daily business events
- extend invoice workflows with paid status updates that automatically create review requests
- refine business service lookup responses to surface candidate businesses and update MCP/LangChain tooling

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d15da38d94832e84119ec6ea8e8021