### PR TITLE
Make agent tool timeouts configurable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     mcp_base_url: AnyHttpUrl = Field(
         default_factory=runtime_default_mcp_base_url, alias="MCP_BASE_URL"
     )
+    agent_tool_timeout: float = Field(default=30.0, alias="AGENT_TOOL_TIMEOUT")
 
     model_config = SettingsConfigDict(env_prefix="QTICK_", case_sensitive=False)
 

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -416,7 +416,9 @@ def summarize_tool_result(
 @lru_cache(maxsize=1)
 def _get_agent_bundle(cache_key: Tuple[str, str, float]):
     settings = get_settings()
-    configure(base_url=str(settings.mcp_base_url))
+    configure(
+        base_url=str(settings.mcp_base_url), timeout=settings.agent_tool_timeout
+    )
     if settings.google_api_key:
         os.environ.setdefault("GOOGLE_API_KEY", settings.google_api_key)
     elif not os.getenv("GOOGLE_API_KEY"):

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -80,9 +80,10 @@ def test_agent_config_uses_runtime_port_default(monkeypatch):
     captured = {}
     real_configure = agent_mod.configure
 
-    def spy_configure(*, base_url: str) -> None:
+    def spy_configure(*, base_url: str, timeout: float | None = None) -> None:
         captured["base_url"] = base_url
-        real_configure(base_url=base_url)
+        captured["timeout"] = timeout
+        real_configure(base_url=base_url, timeout=timeout)
 
     monkeypatch.setattr(agent_mod, "configure", spy_configure)
     monkeypatch.setattr(agent_mod, "ChatGoogleGenerativeAI", lambda **_: object())
@@ -96,6 +97,7 @@ def test_agent_config_uses_runtime_port_default(monkeypatch):
 
     assert captured["base_url"].startswith("http://127.0.0.1:10000")
     assert qtick_module.MCP_BASE == "http://127.0.0.1:10000"
+    assert captured["timeout"] == settings.agent_tool_timeout
 
 
 def test_agent_config_local_default(monkeypatch):


### PR DESCRIPTION
## Summary
- allow configuring the timeout used by agent tools via settings and environment variables
- centralize HTTP request logic in `langchain_tools.qtick` so all tool calls honor the configured timeout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2a9a31c90832eb78906b417b878a7