### PR TITLE
Surface suggested businesses in search responses

### DIFF
--- a/app/schemas/business.py
+++ b/app/schemas/business.py
@@ -23,6 +23,8 @@ class BusinessSearchResponse(BaseModel):
     query: str
     total: int
     items: List[BusinessSummary]
+    message: Optional[str] = None
+    suggested_business_names: Optional[List[str]] = None
 
 
 class ServiceSummary(BaseModel):

--- a/app/services/mock_store.py
+++ b/app/services/mock_store.py
@@ -241,7 +241,38 @@ class MasterDataRepository:
             self._summary_from_record(record)
             for record in matches[:limit]
         ]
-        return BusinessSearchResponse(query=query, total=len(matches), items=items)
+
+        total = len(matches)
+        message: Optional[str] = None
+        suggested_business_names: Optional[List[str]] = None
+        if total == 0:
+            message = "No businesses matched your search."
+        elif total > 1:
+            suggested_business_names = [summary.name for summary in items]
+            option_descriptions = "; ".join(
+                (
+                    f"{summary.name} ({summary.location})"
+                    if summary.location
+                    else summary.name
+                )
+                for summary in items
+            )
+            message = (
+                "Multiple businesses match your search. Please specify the location or "
+                "use the business id."
+            )
+            if option_descriptions:
+                message = f"{message} Options: {option_descriptions}."
+        elif total == 1:
+            suggested_business_names = [items[0].name]
+
+        return BusinessSearchResponse(
+            query=query,
+            total=total,
+            items=items,
+            message=message,
+            suggested_business_names=suggested_business_names,
+        )
 
     def find_services(
         self, business: BusinessRecord, query: str, limit: int

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -190,6 +190,25 @@ def test_service_lookup_returns_candidates_when_business_name_ambiguous() -> Non
     assert response.message and "Multiple businesses" in response.message
 
 
+def test_business_search_returns_suggestions_for_multiple_matches() -> None:
+    client = MockLatencyClient()
+    service = BusinessDirectoryService(client)
+
+    request = BusinessSearchRequest(query="Chillbreeze")
+    response = asyncio.run(service.search(request))
+
+    assert response.total == 3
+    assert response.suggested_business_names is not None
+    assert {
+        "Chillbreeze Adayar",
+        "Chillbrezze Anna Nagar",
+        "Chillbreeze Orchard",
+    } == set(response.suggested_business_names)
+    assert response.message and "Multiple businesses" in response.message
+    for name in response.suggested_business_names:
+        assert name in response.message
+
+
 def test_service_lookup_lists_businesses_for_service_only_query() -> None:
     client = MockLatencyClient()
     service = BusinessDirectoryService(client)
@@ -397,6 +416,8 @@ def test_business_directory_search_and_lookup() -> None:
     names = {item.name for item in search_response.items}
     assert "Chillbrezze Anna Nagar" in names
     assert "Chillbreeze Adayar" in names
+    assert search_response.message is not None
+    assert "Multiple businesses" in search_response.message
 
     lookup_request = ServiceLookupRequest(
         business_name="Chillbreeze",


### PR DESCRIPTION
## Summary
- extend business search responses with a suggested_business_names field for downstream disambiguation prompts
- enrich the mock business search service to populate suggestions and enumerate matching options in the message when multiple businesses match
- add a regression test ensuring Chillbreeze searches now expose the suggestion list in the business directory service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5010ba5bc832e88564f9fc02483b9