### PR TITLE
Expose suggested services in service lookup summaries

### DIFF
--- a/app/schemas/business.py
+++ b/app/schemas/business.py
@@ -64,3 +64,4 @@ class ServiceLookupResponse(BaseModel):
     message: Optional[str] = None
     business_candidates: Optional[List[BusinessSummary]] = None
     service_matches: Optional[List[BusinessServiceMatch]] = None
+    suggested_service_names: Optional[List[str]] = None

--- a/app/services/business.py
+++ b/app/services/business.py
@@ -81,12 +81,18 @@ class BusinessDirectoryService:
                         if exact
                         else "Found one business with related services."
                     )
+                    suggested_names = (
+                        [match.name for match in matches]
+                        if len(matches) > 1
+                        else None
+                    )
                     return ServiceLookupResponse(
                         query=request.service_name,
                         business=business_summary,
                         matches=matches,
                         exact_match=exact,
                         message=message,
+                        suggested_service_names=suggested_names,
                     )
 
                 groups = [
@@ -96,11 +102,19 @@ class BusinessDirectoryService:
                 message = (
                     "Multiple businesses offer this service. Please choose the intended business."
                 )
+                suggested_names = sorted(
+                    {
+                        service.name
+                        for _, matches in grouped
+                        for service in matches
+                    }
+                )
                 return ServiceLookupResponse(
                     query=request.service_name,
                     business_candidates=[group.business for group in groups],
                     service_matches=groups,
                     message=message,
+                    suggested_service_names=suggested_names or None,
                 )
 
             business_record = None
@@ -182,12 +196,17 @@ class BusinessDirectoryService:
                 tags=list(business_record.tags),
             )
 
+            suggested_names = (
+                [match.name for match in matches] if len(matches) > 1 else None
+            )
+
             return ServiceLookupResponse(
                 query=request.service_name,
                 business=business_summary,
                 matches=matches,
                 exact_match=exact,
                 message=message,
+                suggested_service_names=suggested_names,
             )
 
         raise ServiceError("Service lookup is not available in live mode yet")

--- a/tests/test_agent_responses.py
+++ b/tests/test_agent_responses.py
@@ -124,6 +124,7 @@ def test_summarize_service_lookup_groups_matches() -> None:
                 },
             ],
             "message": "Multiple services matched your search.",
+            "suggested_service_names": ["Signature Haircut", "Kids Haircut"],
         },
     )
 
@@ -134,6 +135,7 @@ def test_summarize_service_lookup_groups_matches() -> None:
     assert len(payload["matches"]) == 2
     assert payload["matches"][0]["serviceId"] == 101
     assert payload["message"].startswith("Multiple services")
+    assert payload["suggestedServices"] == ["Signature Haircut", "Kids Haircut"]
 
 
 def test_summarize_business_search_returns_options() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -504,6 +504,23 @@ def test_business_directory_search_and_lookup() -> None:
     assert lookup_response.message is not None
     assert "Multiple businesses matched" in lookup_response.message
 
+    direct_lookup = asyncio.run(
+        service.lookup_service(
+            ServiceLookupRequest(
+                business_id=SEED_CHILLBREEZE_ID,
+                service_name="haircut",
+            )
+        )
+    )
+    assert direct_lookup.business is not None
+    assert direct_lookup.business.business_id == SEED_CHILLBREEZE_ID
+    assert direct_lookup.suggested_service_names is not None
+    assert len(direct_lookup.suggested_service_names) > 1
+    assert all(
+        isinstance(name, str) and name
+        for name in direct_lookup.suggested_service_names
+    )
+
 
 def test_haircut_lookup_with_space_prompts_for_specific_service() -> None:
     client = MockLatencyClient()


### PR DESCRIPTION
## Summary
- include suggested service names in the service lookup response model
- populate suggested service names across mock business lookup paths and surface them to the agent datapoints
- expand service lookup tests and agent summarization coverage for suggested services

## Testing
- pytest tests/test_services.py tests/test_agent_responses.py

------
https://chatgpt.com/codex/tasks/task_b_68d51b35bd84832e9489dd189a2c729e