### PR TITLE
Expand analytics insights across appointments, invoices, and leads

### DIFF
--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -1,13 +1,54 @@
 
-from pydantic import BaseModel
-from typing import List
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 class AnalyticsRequest(BaseModel):
     business_id: int
     metrics: List[str]
     period: str
 
+class ServiceBookingSummary(BaseModel):
+    service_id: Optional[int] = None
+    name: str
+    booking_count: int
+
+
+class ServiceRevenueSummary(BaseModel):
+    service_id: Optional[int] = None
+    name: str
+    total_revenue: float
+    currency: Optional[str] = None
+
+
+class StatusBreakdown(BaseModel):
+    total: int
+    by_status: Dict[str, int] = Field(default_factory=dict)
+
+
+class AppointmentAnalytics(StatusBreakdown):
+    unique_customers: int = 0
+
+
+class InvoiceAnalytics(StatusBreakdown):
+    total_revenue: float
+    paid_total: float
+    outstanding_total: float
+    average_invoice_value: Optional[float] = None
+    currency: Optional[str] = None
+    unique_customers: int = 0
+
+
+class LeadAnalytics(StatusBreakdown):
+    source_breakdown: Dict[str, int] = Field(default_factory=dict)
+
+
 class AnalyticsResponse(BaseModel):
     footfall: int
     revenue: str
     report_generated_at: str
+    top_appointment_service: Optional[ServiceBookingSummary] = None
+    highest_revenue_service: Optional[ServiceRevenueSummary] = None
+    appointment_summary: Optional[AppointmentAnalytics] = None
+    invoice_summary: Optional[InvoiceAnalytics] = None
+    lead_summary: Optional[LeadAnalytics] = None

--- a/app/schemas/billing.py
+++ b/app/schemas/billing.py
@@ -10,6 +10,7 @@ class LineItem(BaseModel):
     unit_price: Optional[float] = None  # primary
     price: Optional[float] = None       # alias accepted by API/tool layer
     tax_rate: float = 0.0               # e.g. 0.08 for 8%
+    service_id: Optional[int] = None    # optional reference to master data
 
 class InvoiceRequest(BaseModel):
     business_id: int

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -414,13 +414,69 @@ def _summarize_campaign(output: Dict[str, Any], tool_input: Optional[Dict[str, A
 
 
 def _summarize_analytics(output: Dict[str, Any]) -> Dict[str, Any]:
-    return _strip_nones(
-        {
-            "footfall": output.get("footfall"),
-            "revenue": output.get("revenue"),
-            "reportGeneratedAt": output.get("report_generated_at"),
-        }
-    )
+    summary: Dict[str, Any] = {
+        "footfall": output.get("footfall"),
+        "revenue": output.get("revenue"),
+        "reportGeneratedAt": output.get("report_generated_at"),
+    }
+
+    top_service = output.get("top_appointment_service")
+    if isinstance(top_service, dict):
+        summary["topAppointmentService"] = _strip_nones(
+            {
+                "serviceId": top_service.get("service_id"),
+                "name": top_service.get("name"),
+                "bookingCount": top_service.get("booking_count"),
+            }
+        )
+
+    highest_revenue = output.get("highest_revenue_service")
+    if isinstance(highest_revenue, dict):
+        summary["highestRevenueService"] = _strip_nones(
+            {
+                "serviceId": highest_revenue.get("service_id"),
+                "name": highest_revenue.get("name"),
+                "totalRevenue": highest_revenue.get("total_revenue"),
+                "currency": highest_revenue.get("currency"),
+            }
+        )
+
+    appointment_summary = output.get("appointment_summary")
+    if isinstance(appointment_summary, dict):
+        summary["appointmentSummary"] = _strip_nones(
+            {
+                "total": appointment_summary.get("total"),
+                "byStatus": appointment_summary.get("by_status"),
+                "uniqueCustomers": appointment_summary.get("unique_customers"),
+            }
+        )
+
+    invoice_summary = output.get("invoice_summary")
+    if isinstance(invoice_summary, dict):
+        summary["invoiceSummary"] = _strip_nones(
+            {
+                "total": invoice_summary.get("total"),
+                "byStatus": invoice_summary.get("by_status"),
+                "totalRevenue": invoice_summary.get("total_revenue"),
+                "paidTotal": invoice_summary.get("paid_total"),
+                "outstandingTotal": invoice_summary.get("outstanding_total"),
+                "averageInvoiceValue": invoice_summary.get("average_invoice_value"),
+                "currency": invoice_summary.get("currency"),
+                "uniqueCustomers": invoice_summary.get("unique_customers"),
+            }
+        )
+
+    lead_summary = output.get("lead_summary")
+    if isinstance(lead_summary, dict):
+        summary["leadSummary"] = _strip_nones(
+            {
+                "total": lead_summary.get("total"),
+                "byStatus": lead_summary.get("by_status"),
+                "sourceBreakdown": lead_summary.get("source_breakdown"),
+            }
+        )
+
+    return _strip_nones(summary)
 
 
 def _summarize_datetime(output: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_agent_responses.py
+++ b/tests/test_agent_responses.py
@@ -173,3 +173,71 @@ def test_summarize_business_search_returns_options() -> None:
 
     message = data_points[3]
     assert message["message"].startswith("Multiple businesses match")
+
+
+def test_summarize_analytics_includes_service_insights() -> None:
+    _, data_points = summarize_tool_result(
+        "analytics_report",
+        None,
+        {
+            "footfall": 42,
+            "revenue": "SGD 1,234.00",
+            "report_generated_at": "2025-09-07T00:00:00+00:00",
+            "top_appointment_service": {
+                "service_id": 303,
+                "name": "Men's Haircut",
+                "booking_count": 12,
+            },
+            "highest_revenue_service": {
+                "service_id": 302,
+                "name": "Soothing Head Massage",
+                "total_revenue": 540.0,
+                "currency": "SGD",
+            },
+            "appointment_summary": {
+                "total": 18,
+                "by_status": {"confirmed": 16, "cancelled": 2},
+                "unique_customers": 14,
+            },
+            "invoice_summary": {
+                "total": 20,
+                "by_status": {"paid": 15, "created": 5},
+                "total_revenue": 3250.0,
+                "paid_total": 2875.0,
+                "outstanding_total": 375.0,
+                "average_invoice_value": 162.5,
+                "currency": "SGD",
+                "unique_customers": 12,
+            },
+            "lead_summary": {
+                "total": 9,
+                "by_status": {"new": 7, "contacted": 2},
+                "source_breakdown": {
+                    "instagram": 4,
+                    "referral": 3,
+                    "walk-in": 2,
+                },
+            },
+        },
+    )
+
+    assert len(data_points) == 1
+    payload = data_points[0]
+    top_service = payload["topAppointmentService"]
+    assert top_service["serviceId"] == 303
+    assert top_service["bookingCount"] == 12
+    highest = payload["highestRevenueService"]
+    assert highest["name"] == "Soothing Head Massage"
+    assert highest["totalRevenue"] == 540.0
+    appointment_summary = payload["appointmentSummary"]
+    assert appointment_summary["total"] == 18
+    assert appointment_summary["byStatus"]["confirmed"] == 16
+    assert appointment_summary["uniqueCustomers"] == 14
+    invoice_summary = payload["invoiceSummary"]
+    assert invoice_summary["totalRevenue"] == 3250.0
+    assert invoice_summary["outstandingTotal"] == 375.0
+    assert invoice_summary["uniqueCustomers"] == 12
+    lead_summary = payload["leadSummary"]
+    assert lead_summary["total"] == 9
+    assert lead_summary["byStatus"]["new"] == 7
+    assert lead_summary["sourceBreakdown"]["instagram"] == 4


### PR DESCRIPTION
## Summary
- extend the analytics schema to cover status breakdowns for appointments, invoices, and leads
- enrich the mock analytics repository so reports aggregate booking counts, invoice financials, and lead sources
- surface the expanded analytics data through the agent summariser, tool description, and new tests validating the workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5542a4d6c832eb7647f07effab88b