### PR TITLE
Document MCP client transports and SSE controller workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,35 @@
 # QTick MCP Service (Full, Consolidated)
 
 ## Windows 10 Quickstart
-```bat
-cd C:\projects\qtick_mcp_full
-python -m venv venv
-venv\Scripts\activate
-pip install -r requirements.txt
-uvicorn app.main:app --reload
-```
 
-Open Swagger at http://127.0.0.1:8000/docs and try:
-- POST /tools/appointment/book
-- POST /tools/appointment/list
-- POST /tools/invoice/create
-- POST /tools/leads/create
-- POST /tools/campaign/sendWhatsApp
-- POST /tools/analytics/report
+1. **Boot the API**
+   ```bat
+   cd C:\projects\qtick_mcp_full
+   python -m venv venv
+   venv\Scripts\activate
+   pip install -r requirements.txt
+   uvicorn app.main:app --reload
+   ```
+   Open Swagger at http://127.0.0.1:8000/docs and try:
+   - POST /tools/appointment/book
+   - POST /tools/appointment/list
+   - POST /tools/invoice/create
+   - POST /tools/leads/create
+   - POST /tools/campaign/sendWhatsApp
+   - POST /tools/analytics/report
+
+2. **Pick an MCP transport** – The repo includes ready-made harnesses that wire
+   up `mcp.client.session.ClientSession` with either JSON-RPC over stdio or
+   server-sent events (SSE):
+   - `TEST_mcp_client.py` – stdio transport for local subprocess connectivity.
+   - `TEST_mcp_client_stream.py` – streaming JSON transport over TCP.
+   - `TEST_mcp_client_sse.py` – SSE harness that connects to
+     `http://127.0.0.1:8000/sse`.
+
+   Each script exposes a minimal checklist: initialise the session, list the
+   advertised tools, and make a sample `ping` call. Copy one of them when
+   bootstrapping your own client to ensure you configure the right
+   `ClientSession` transport and headers.
 
 ## Multi-step tool reasoning
 


### PR DESCRIPTION
## Summary
- expand the Windows quickstart to highlight the provided ClientSession transport harnesses for stdio, TCP streaming, and SSE
- align the tool catalogue with FastMCP and REST names for appointments, invoices, leads, and reviews
- refresh the multi-entity controller example to demonstrate the SSE transport, normalised CallToolResult handling, and a pluggable LLM completion hook

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d69dc712b8832e8085036f43c8535c