### PR TITLE
Standardize agent on Gemini and handle multi-part prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ set GOOGLE_API_KEY=YOUR_MAKERSUITE_API_KEY
 python test_agent_gemini.py
 ```
 
+### Agent LLM configuration
+
+The agent runtime is standardised on Google Gemini. Configure it with the following knobs:
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `QTICK_AGENT_GOOGLE_MODEL` | Gemini model name used by the agent. | `gemini-1.5-flash` |
+| `QTICK_AGENT_TEMPERATURE` | Sampling temperature applied to the Gemini model. | `0.0` |
+| `QTICK_GOOGLE_API_KEY` | Server-side Gemini API key (fallbacks to `GOOGLE_API_KEY`). | – |
+
+When `QTICK_GOOGLE_API_KEY` is set the value is copied into `GOOGLE_API_KEY` so LangChain and
+other downstream clients inherit the same credential automatically.
+
+The `/agent/run` endpoint accepts either a single string prompt or a multi-part prompt payload
+(lists of strings and/or `{role, content}` dictionaries). The server flattens these segments
+into a single Gemini-friendly string before dispatching the request, so you can stream complex
+conversation context without changing the API contract.
+
 If imports act weird after overwriting files, clear caches:
 ```bat
 rmdir /S /Q app\__pycache__

--- a/app/config.py
+++ b/app/config.py
@@ -25,7 +25,7 @@ def runtime_default_mcp_base_url() -> str:
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
-    app_name: str = Field(default="QTick MCP Service", alias="APP_NAME")
+    app_name: str = Field(default="QTick MCP Service")
     cors_origins: List[AnyHttpUrl] = Field(
         default_factory=lambda: [
             "http://localhost:5500",
@@ -35,17 +35,29 @@ class Settings(BaseSettings):
         ]
     )
     java_service_base_url: AnyHttpUrl | None = Field(
-        default=None, alias="JAVA_SERVICE_BASE_URL"
+        default=None
     )
-    java_service_timeout: float = Field(default=10.0, alias="JAVA_SERVICE_TIMEOUT")
-    use_mock_data: bool = Field(default=True, alias="USE_MOCK_DATA")
-    google_api_key: str | None = Field(default=None, alias="GOOGLE_API_KEY")
-    agent_google_model: str = Field(default="gemini-1.5-flash", alias="AGENT_GOOGLE_MODEL")
-    agent_temperature: float = Field(default=0.0, alias="AGENT_TEMPERATURE")
+    java_service_timeout: float = Field(
+        default=10.0
+    )
+    use_mock_data: bool = Field(
+        default=True
+    )
+    google_api_key: str | None = Field(
+        default=None
+    )
+    agent_google_model: str = Field(
+        default="gemini-1.5-flash"
+    )
+    agent_temperature: float = Field(
+        default=0.0
+    )
     mcp_base_url: AnyHttpUrl = Field(
-        default_factory=runtime_default_mcp_base_url, alias="MCP_BASE_URL"
+        default_factory=runtime_default_mcp_base_url
     )
-    agent_tool_timeout: float = Field(default=30.0, alias="AGENT_TOOL_TIMEOUT")
+    agent_tool_timeout: float = Field(
+        default=30.0
+    )
 
     model_config = SettingsConfigDict(env_prefix="QTICK_", case_sensitive=False)
 
@@ -54,7 +66,6 @@ class Settings(BaseSettings):
         if isinstance(value, str):
             return [origin.strip() for origin in value.split(",") if origin.strip()]
         return value
-
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/tests/test_agent_run.py
+++ b/tests/test_agent_run.py
@@ -2,12 +2,15 @@ import importlib
 import os
 import sys
 import threading
+import types
 
+import pytest
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.main import app
+from app.schemas.agent import AgentRunRequest
 import app.tools.agent as agent_module
 
 
@@ -59,6 +62,38 @@ def test_agent_run_endpoint_uses_background_thread(monkeypatch):
     assert agent.thread_ident != loop_thread_ident
 
 
+def test_agent_run_request_normalizes_prompt_sequences():
+    payload = {
+        "prompt": [
+            "system: keep answers short",
+            {"role": "user", "content": "Hi"},
+            ["Follow up", {"role": "assistant", "content": "Sure"}],
+        ]
+    }
+
+    req = AgentRunRequest.model_validate(payload)
+
+    assert "system: keep answers short" in req.prompt
+    assert "user: Hi" in req.prompt
+    assert "Follow up" in req.prompt
+    assert "assistant: Sure" in req.prompt
+
+
+def test_agent_run_request_accepts_raw_prompt_list():
+    payload = ["alpha", "beta"]
+
+    req = AgentRunRequest.model_validate(payload)
+
+    assert req.prompt == "alpha\n\nbeta"
+
+
+def test_agent_run_request_accepts_dict_prompt():
+    payload = {"role": "system", "content": "You are helpful."}
+
+    req = AgentRunRequest.model_validate(payload)
+
+    assert req.prompt == "system: You are helpful."
+
 def test_agent_config_uses_runtime_port_default(monkeypatch):
     monkeypatch.delenv("QTICK_MCP_BASE_URL", raising=False)
     monkeypatch.delenv("MCP_BASE_URL", raising=False)
@@ -66,6 +101,8 @@ def test_agent_config_uses_runtime_port_default(monkeypatch):
     monkeypatch.setenv("PORT", "10000")
     monkeypatch.setenv("QTICK_GOOGLE_API_KEY", "test-key")
     monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("QTICK_AGENT_GOOGLE_MODEL", "gemini-1.5-pro")
+    monkeypatch.setenv("QTICK_AGENT_TEMPERATURE", "0.25")
 
     import app.config as config_module
     import langchain_tools.qtick as qtick_module
@@ -86,7 +123,20 @@ def test_agent_config_uses_runtime_port_default(monkeypatch):
         real_configure(base_url=base_url, timeout=timeout)
 
     monkeypatch.setattr(agent_mod, "configure", spy_configure)
-    monkeypatch.setattr(agent_mod, "ChatGoogleGenerativeAI", lambda **_: object())
+
+    captured_llm = {}
+
+    def fake_build_llm(model_name, temperature, cfg):
+        captured_llm.update(
+            {
+                "model_name": model_name,
+                "temperature": temperature,
+                "settings": cfg,
+            }
+        )
+        return object()
+
+    monkeypatch.setattr(agent_mod, "_build_llm", fake_build_llm)
     monkeypatch.setattr(agent_mod, "initialize_agent", lambda **_: object())
 
     config_module.get_settings.cache_clear()
@@ -98,6 +148,8 @@ def test_agent_config_uses_runtime_port_default(monkeypatch):
     assert captured["base_url"].startswith("http://127.0.0.1:10000")
     assert qtick_module.MCP_BASE == "http://127.0.0.1:10000"
     assert captured["timeout"] == settings.agent_tool_timeout
+    assert captured_llm["model_name"] == settings.agent_google_model
+    assert captured_llm["temperature"] == settings.agent_temperature
 
 
 def test_agent_config_local_default(monkeypatch):
@@ -116,3 +168,39 @@ def test_agent_config_local_default(monkeypatch):
 
     assert config_module.runtime_default_mcp_base_url() == "http://localhost:8000"
     assert qtick_module.MCP_BASE == "http://localhost:8000"
+
+
+def test_build_llm_requires_google_api_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    import app.tools.agent as agent_mod
+
+    agent_mod = importlib.reload(agent_mod)
+
+    settings = types.SimpleNamespace(
+        google_api_key=None,
+        agent_google_model="gemini-1.5-flash",
+    )
+
+    with pytest.raises(agent_mod.HTTPException) as exc:
+        agent_mod._build_llm(settings.agent_google_model, 0.0, settings)
+
+    assert "GOOGLE_API_KEY" in str(exc.value)
+
+
+def test_build_llm_sets_google_api_key(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    import app.tools.agent as agent_mod
+
+    agent_mod = importlib.reload(agent_mod)
+
+    settings = types.SimpleNamespace(
+        google_api_key="server-key",
+        agent_google_model="gemini-1.5-pro",
+    )
+
+    llm = agent_mod._build_llm(settings.agent_google_model, 0.2, settings)
+
+    assert llm is not None
+    assert os.getenv("GOOGLE_API_KEY") == "server-key"


### PR DESCRIPTION
## Summary
- remove the OpenAI configuration surface and dependency so the agent always uses Google Gemini
- normalize multi-part prompt payloads into a Gemini-friendly string before invoking the agent
- update documentation and tests to reflect the Gemini-only runtime and new prompt handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d6a0b71cb8832eacf2787b458804b8