### PR TITLE
Add agent smoke test utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,27 @@ rmdir /S /Q app\tools\__pycache__
 rmdir /S /Q app\schemas\__pycache__
 rmdir /S /Q langchain_tools\__pycache__
 ```
+
+## Pre-merge smoke test
+
+Before merging changes that touch the agent service, run the automated smoke
+test locally to confirm that the configured Gemini model is reachable and the
+FastAPI endpoint responds correctly:
+
+```bash
+export QTICK_GOOGLE_API_KEY=YOUR_MAKERSUITE_API_KEY
+python scripts/agent_smoke_test.py
+```
+
+You can override the default prompt or timeout if needed:
+
+```bash
+python scripts/agent_smoke_test.py --prompt "Say hello" --timeout 90
+```
+
+For CI-style checks without calling external services, continue to rely on the
+unit test suite:
+
+```bash
+pytest
+```

--- a/app/config.py
+++ b/app/config.py
@@ -40,7 +40,9 @@ class Settings(BaseSettings):
     java_service_timeout: float = Field(default=10.0, alias="JAVA_SERVICE_TIMEOUT")
     use_mock_data: bool = Field(default=True, alias="USE_MOCK_DATA")
     google_api_key: str | None = Field(default=None, alias="GOOGLE_API_KEY")
-    agent_google_model: str = Field(default="gemini-pro", alias="AGENT_GOOGLE_MODEL")
+    agent_google_model: str = Field(
+        default="gemini-1.5-flash-latest", alias="AGENT_GOOGLE_MODEL"
+    )
     agent_temperature: float = Field(default=0.0, alias="AGENT_TEMPERATURE")
     mcp_base_url: AnyHttpUrl = Field(
         default_factory=runtime_default_mcp_base_url, alias="MCP_BASE_URL"

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -587,7 +587,7 @@ async def run_agent(
             status_code=500,
             detail=(
                 "Agent model is unavailable. Configure QTICK_AGENT_GOOGLE_MODEL "
-                "to a supported model such as 'gemini-pro'. Original error: "
+                "to a supported model such as 'gemini-1.5-flash-latest'. Original error: "
                 f"{exc}"
             ),
         ) from exc

--- a/scripts/agent_smoke_test.py
+++ b/scripts/agent_smoke_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run a quick agent smoke test against the local FastAPI service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict
+
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.main import app
+import app.tools.agent as agent_module
+
+
+def _ensure_api_key() -> None:
+    settings = get_settings()
+    if settings.google_api_key:
+        # Settings already exposes the key through QTICK_GOOGLE_API_KEY.
+        os.environ.setdefault("GOOGLE_API_KEY", settings.google_api_key)
+    elif not os.getenv("GOOGLE_API_KEY"):
+        raise RuntimeError(
+            "GOOGLE_API_KEY environment variable is required for the smoke test."
+        )
+
+
+def _format_data_points(data_points: Any) -> str:
+    if not data_points:
+        return "[]"
+    try:
+        return json.dumps(data_points, indent=2, ensure_ascii=False)
+    except TypeError:
+        return str(data_points)
+
+
+def run_smoke_test(prompt: str, request_timeout: float) -> Dict[str, Any]:
+    """Execute the /agent/run endpoint with the provided prompt."""
+
+    # Ensure configuration changes are respected between runs.
+    get_settings.cache_clear()
+    agent_module._get_agent_bundle.cache_clear()
+
+    _ensure_api_key()
+
+    settings = get_settings()
+    print(
+        f"Running smoke test with model '{settings.agent_google_model}' at "
+        f"{settings.mcp_base_url}"
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agent/run",
+            json={"prompt": prompt},
+            timeout=request_timeout,
+        )
+
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Agent run failed ({response.status_code}): {response.text}"
+        )
+
+    payload: Dict[str, Any] = response.json()
+    print("Model response:")
+    print(payload.get("output", "<no output>"))
+
+    print("\nTool triggered:")
+    print(payload.get("tool"))
+
+    print("\nData points:")
+    print(_format_data_points(payload.get("dataPoints")))
+
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a smoke test against the local agent service. The test sends a "
+            "prompt through the /agent/run endpoint using the configured Gemini "
+            "model."
+        )
+    )
+    parser.add_argument(
+        "--prompt",
+        default="Summarize the purpose of the QTick MCP service in one sentence.",
+        help="Prompt to send to the agent during the smoke test.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Timeout (in seconds) for the agent HTTP request.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        run_smoke_test(args.prompt, args.timeout)
+    except Exception as exc:  # pragma: no cover - manual diagnostic utility
+        print(f"Smoke test failed: {exc}", file=sys.stderr)
+        return 1
+
+    print("\nSmoke test completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual diagnostic utility
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standalone smoke test script that exercises the /agent/run endpoint with the configured Gemini model
- document how to run the smoke test and existing pytest suite before merging changes to the agent service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d7421c11a0832e8d4d11b1c6c6ed35