### PR TITLE
Update default Gemini model to 2.5 flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Before merging changes that touch the agent service, run the automated smoke
 test locally to confirm that the configured Gemini model is reachable and the
 FastAPI endpoint responds correctly:
 
+> The service defaults to `gemini-2.5-flash`. Override it by exporting
+> `QTICK_AGENT_GOOGLE_MODEL` if you need to target a different release.
+
 ```bash
 export QTICK_GOOGLE_API_KEY=YOUR_MAKERSUITE_API_KEY
 python scripts/agent_smoke_test.py

--- a/app/config.py
+++ b/app/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     use_mock_data: bool = Field(default=True, alias="USE_MOCK_DATA")
     google_api_key: str | None = Field(default=None, alias="GOOGLE_API_KEY")
     agent_google_model: str = Field(
-        default="gemini-1.5-flash-latest", alias="AGENT_GOOGLE_MODEL"
+        default="gemini-2.5-flash", alias="AGENT_GOOGLE_MODEL"
     )
     agent_temperature: float = Field(default=0.0, alias="AGENT_TEMPERATURE")
     mcp_base_url: AnyHttpUrl = Field(

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -587,7 +587,7 @@ async def run_agent(
             status_code=500,
             detail=(
                 "Agent model is unavailable. Configure QTICK_AGENT_GOOGLE_MODEL "
-                "to a supported model such as 'gemini-1.5-flash-latest'. Original error: "
+                "to a supported model such as 'gemini-2.5-flash'. Original error: "
                 f"{exc}"
             ),
         ) from exc

--- a/test_agent_gemini.py
+++ b/test_agent_gemini.py
@@ -26,7 +26,7 @@ tools = [
     analytics_tool(),
 ]
 
-llm = ChatGoogleGenerativeAI(model="gemini-1.5-flash", temperature=0)
+llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=0)
 
 agent = initialize_agent(
     tools=tools,


### PR DESCRIPTION
## Summary
- set the default agent model to gemini-2.5-flash
- update the error guidance, documentation, and smoke test script to match the new default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d745a52034832ea30833d8f7201140