### PR TITLE
Fix LangChain compatibility for agent services

### DIFF
--- a/app/schemas/daily_summary.py
+++ b/app/schemas/daily_summary.py
@@ -66,7 +66,7 @@ class DailySummaryData(BaseModel):
     business: BusinessSummary
     date: str
     generated_at: str
-    metrics: List[str]
+    metrics: List[Union[str, DailySummaryMetric]]
 
 
 class DailySummaryResponse(DailySummaryData):

--- a/app/services/agent_logging.py
+++ b/app/services/agent_logging.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.schema import AgentAction, AgentFinish, LLMResult
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.agents import AgentAction, AgentFinish
+from langchain_core.outputs import LLMResult
 
 logger = logging.getLogger("app.agent")
 logger.setLevel(logging.INFO)

--- a/app/services/langchain_compat.py
+++ b/app/services/langchain_compat.py
@@ -1,0 +1,125 @@
+"""Compatibility helpers for LangChain's evolving agent APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, List, Mapping, MutableMapping, Optional, Sequence
+
+def _ensure_pydantic_v1() -> None:
+    """Provide ``langchain_core.pydantic_v1`` if the distribution omits it."""
+
+    try:  # pragma: no cover - only executed on newer langchain builds
+        import langchain_core.pydantic_v1  # type: ignore
+        return
+    except ImportError:
+        pass
+
+    import sys
+    import types
+
+    from pydantic import v1 as pydantic_v1
+
+    module = types.ModuleType("langchain_core.pydantic_v1")
+    module.BaseModel = pydantic_v1.BaseModel
+    module.Field = pydantic_v1.Field
+    module.ValidationError = pydantic_v1.ValidationError
+    module.root_validator = pydantic_v1.root_validator
+    module.validator = pydantic_v1.validator
+    module.__all__ = [
+        "BaseModel",
+        "Field",
+        "ValidationError",
+        "root_validator",
+        "validator",
+    ]
+
+    sys.modules.setdefault("langchain_core.pydantic_v1", module)
+
+
+_ensure_pydantic_v1()
+
+from langchain.agents import create_agent
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import BaseMessage, HumanMessage
+
+
+class AgentType(str, Enum):
+    """Subset of historical ``AgentType`` enum values that we rely on."""
+
+    STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION = (
+        "structured-chat-zero-shot-react-description"
+    )
+
+
+def _extract_message_text(message: BaseMessage) -> str:
+    """Return a readable string from a LangChain message instance."""
+
+    content: Any = getattr(message, "content", "")
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, Sequence):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, Mapping):
+                if item.get("type") == "text" and "text" in item:
+                    parts.append(str(item["text"]))
+                elif "text" in item:
+                    parts.append(str(item["text"]))
+            elif isinstance(item, str):
+                parts.append(item)
+        if parts:
+            return "".join(parts)
+
+    return str(content)
+
+
+@dataclass
+class _StructuredChatAgent:
+    """Minimal wrapper that mimics the legacy agent executor interface."""
+
+    graph: Any
+    base_callbacks: Sequence[BaseCallbackHandler]
+
+    def run(self, prompt: str, callbacks: Optional[Sequence[BaseCallbackHandler]] = None) -> str:
+        """Execute the agent graph with the provided prompt."""
+
+        messages = {"messages": [HumanMessage(content=prompt)]}
+        merged_callbacks: List[BaseCallbackHandler] = list(self.base_callbacks)
+        if callbacks:
+            merged_callbacks.extend(callbacks)
+
+        config: MutableMapping[str, Any] = {}
+        if merged_callbacks:
+            config["callbacks"] = merged_callbacks
+
+        result: Mapping[str, Any] = self.graph.invoke(messages, config=config or None)
+        history = result.get("messages", [])
+        if not history:
+            return ""
+
+        return _extract_message_text(history[-1])
+
+
+def initialize_agent(
+    *,
+    tools: Optional[Sequence[Any]],
+    llm: Any,
+    agent: AgentType,
+    verbose: bool = False,
+    callbacks: Optional[Sequence[BaseCallbackHandler]] = None,
+    **_: Any,
+) -> _StructuredChatAgent:
+    """Backwards compatible ``initialize_agent`` helper."""
+
+    if agent is not AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION:
+        raise ValueError(f"Unsupported agent type: {agent}")
+
+    graph = create_agent(model=llm, tools=tools or None)
+
+    return _StructuredChatAgent(graph=graph, base_callbacks=list(callbacks or ()))
+
+
+__all__ = ["AgentType", "initialize_agent"]
+

--- a/app/tools/agent.py
+++ b/app/tools/agent.py
@@ -14,7 +14,7 @@ from app.schemas.agent import AgentRunRequest, AgentRunResponse, AgentToolsRespo
 from app.services.agent_logging import AgentLoggingCallbackHandler, AgentRunCollector
 
 from app.services.conversation_memory import ConversationTurn, conversation_memory
-from langchain.agents import AgentType, initialize_agent
+from app.services.langchain_compat import AgentType, initialize_agent
 from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langchain_tools.qtick import (

--- a/langchain_tools/qtick.py
+++ b/langchain_tools/qtick.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import dateparser
 import requests
 from zoneinfo import ZoneInfo
-from langchain.tools import StructuredTool
+from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.config import runtime_default_mcp_base_url

--- a/test_agent.py
+++ b/test_agent.py
@@ -1,6 +1,6 @@
 from langchain.chat_models import ChatOpenAI
-from langchain.agents import initialize_agent, AgentType
-from langchain.tools import Tool
+from app.services.langchain_compat import AgentType, initialize_agent
+from langchain_core.tools import Tool
 
 # Import your QTick tools
 from langchain_tools.qtick import (
@@ -20,7 +20,7 @@ llm = ChatOpenAI(temperature=0, model="gpt-3.5-turbo", openai_api_key="sk-...")
 agent = initialize_agent(
     tools=tools,
     llm=llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
     verbose=True
 )
 

--- a/test_agent_gemini.py
+++ b/test_agent_gemini.py
@@ -2,7 +2,7 @@
 # test_agent_gemini.py
 import os
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain.agents import initialize_agent, AgentType
+from app.services.langchain_compat import AgentType, initialize_agent
 
 os.environ.setdefault("GOOGLE_API_KEY", os.getenv("GOOGLE_API_KEY"))
 


### PR DESCRIPTION
## Summary
- add a local langchain compatibility layer to shim the removed callbacks and agent APIs
- update agent, logging, and tool modules to use langchain_core imports and the new compatibility helpers
- adjust daily summary models/service and sample scripts to work with the updated data structures

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ea40ab6e0832e8976ef2ccff5e501)